### PR TITLE
[FIND DUPLICATE CASES SKILL] add rule to distinguish different test level

### DIFF
--- a/skills/check-api-client-from-swagger/SKILL.md
+++ b/skills/check-api-client-from-swagger/SKILL.md
@@ -1,0 +1,31 @@
+---
+name: check-api-client-from-swagger
+description: Update API test client from changed fround in swagger.json. Tracks changes in swagger.json file, in case of changes updates api client, attempts to use dto types.
+---
+
+# CHECK-UPDATES-API-CLIENT-FROM-SWAGGER SKILL: What I do
+
+Detect and manage duplicate test cases in user project. Provide clear recommendations for cleanup actions.
+
+## When to Use
+
+Triggers to quickly ensure that API client is sound
+- when API test is failing
+- when implementing new functionality that requires API setup
+- user asks to check state of api client
+
+---
+
+## Workflow
+
+1) check `playwirght_config.ts` and `.env` for new api servers. Specifically look for values like <SERVER_NAME>_SWAGGER_URL, SWAGGER_JSON_URL,  etc. <SERVER_NAME> is for cases when there are several backend instances
+
+2) Check every swagger file `./apiClient/servers/<serverName>/swagger.json` if present
+
+3) for every swagger.json without corresponding <SERVER_NAME>_SWAGGER_URL url dectected, notify user that this server apiClient is not refreshed
+
+4) try to fetch <SERVER_NAME>_SWAGGER_JSON_URL and save pretified json in `./apiClient/servers/<serverName>/swagger.json`. If auth error is returned try to use admin:admin, if error persist give user information about problem ask for further instructions.
+
+5) check git changes in the swagger.json files. If no changes detected than you finished give short message that no changes were detected and inline list of servers that have apiClient on them !STOP SKILL EXECTUION!
+
+6) if changes in `<serverName>/swagger.json` files are present give short change list to user and trigger update-api-client-from-swagger skill

--- a/skills/find-duplicate-cases/SKILL.md
+++ b/skills/find-duplicate-cases/SKILL.md
@@ -40,6 +40,7 @@ Compare all extracted tests to identify potential duplicates.
 - Normalize step wording where possible.
 - Ignore framework syntax (`describe`, `Scenario`, `it`, etc.) when analyzing intent.
 - Treat parameterized values (emails, IDs, usernames) as variable data.
+- Treat tests from different levels that have a similar title as different tests. E.g. API test with "Product CRUD" title in is different from UI test with "Product CRUD" title, as they check integration of different elements.
 
 2) Compare tests using multiple similarity signals:
 - **Title similarity**.


### PR DESCRIPTION
Additional guard rail to prevent agent from clumping together tests by similarity of their title and test-steps, like
 "X Product CRUD" => Create step => Update Step => Delete step 