### PR TITLE
DRAFT - [SYNC CASES] Allow MCP tools in skill

### DIFF
--- a/skills/sync-cases/SKILL.md
+++ b/skills/sync-cases/SKILL.md
@@ -30,43 +30,6 @@ Keywords: sync, synchronize cases, pull, push, export, import, download, import.
 
 ---
 
-## Testomat MCP Tool Policy
-
-This skill uses Testomat MCP only when MCP tools provide better precision than the `check-tests` CLI.
-
-### Allowed MCP Tools
-
-| Tool            | When to Use            |
-|-----------------|------------------------|
-| `tags_get`      | Get tests by tag title |
-| `tests_get`     | Get single test by ID (to verify or inspect) |
-| `tests_update`  | Update specific test attributes (priority, tags, labels) by ID |
-| `suites_get`    | Get suite info by ID |
-| `suites_update` | Update specific suite attributes (priority, tags, labels) by ID |
-| `labels_list`   | List available labels |
-| `labels_create` | Create a new label |
-| `labels_update` | Update existing label |
-
-### Use `check-tests` CLI (Default)
-
-- Bulk pull/push operations.
-- From-scratch sync.
-- Any operation without specific test IDs.
-- Directory-based import/export.
-
-### Use MCP Tools (Restricted)
-
-Only when user explicitly requests:
-- Update a **specific test** by ID (`tests_update`).
-- Change test **attributes** on existing tests (priority, tags, labels).
-- Search/get single test or suite by ID.
-
-### Blocking Rule
-
-If request involves "all tests", "bulk", "pull everything", "push all" => **prefer to use `check-tests` CLI** options, instead of MCP.
-
----
-
 ## Workflow: Sync Test Cases
 
 ### Step 1: Environment Setup
@@ -76,6 +39,19 @@ If request involves "all tests", "bulk", "pull everything", "push all" => **pref
 Check if "TESTOMATIO" token was provided as input:
 - If not provided, check for `.env` file in project root.
   - If still not found => ❓ ask user for token.
+
+### Check Required Tools
+
+| Tool      | Purpose                              |
+|-----------|--------------------------------------|
+| `bash`    | Execute npx check-tests pull/push   |
+| `write`   | Create markdown files locally        |
+| `glob`    | Find existing test files             |
+| `read`    | Parse test file content              |
+
+> If any tools issue are disabled => **inform user about issue and stop**
+  - Ask user to check agent available tool list.
+  - **Do not attempt workarounds.**
 
 #### Save Credentials to .env File
 
@@ -178,6 +154,24 @@ npx check-tests push -d manual-tests
 
 **More examples** you can find in "Push" section [Testomat.io CLI Documentation](./references/TESTOMATIO_CLI.md)
 
+#### Verify Changes by Testomat MCP Tool (if enabled)
+
+Use MCP tools for checking and **updating existing test attributes**:
+
+| MCP Tool        | Use Case                                    |
+|----------------|---------------------------------------------|
+| `tests_update`   | Change priority, creator, labels on existing test by ID |
+| `suites_update` | Change suite attributes by ID |
+| `labels_create` | Create new label in TMS |
+| `labels_update` | Update existing label in test case |
+
+**Example workflow:**
+1. Pull tests: `npx check-tests pull -d folder`.
+2. Edit local `.test.md` files (update `priority:`, `labels:` in md metadata).
+3. Push updates => **use MCP** `tests_update` per test (not CLI push, which would rewrite everything).
+
+> If some suite/test metadata not synced - use Testomat MCP tool to save changes.
+
 ---
 
 ## Final Summary Example
@@ -212,6 +206,7 @@ Stop execution if:
 - Cannot create `.env` file by system.
 - Directory creation fails.
 - CLI sync command fails (network/auth/401/403).
+- MCP tools issue.
 
 ---
 

--- a/skills/sync-cases/SKILL.md
+++ b/skills/sync-cases/SKILL.md
@@ -26,6 +26,45 @@ Trigger this skill when user wants to:
 - Synchronize test cases between local `.md` files and Testomat.io TMS.
 - Cover user bulk edit workflow: pull cases -> edit test cases -> push cases to TMS.
 
+Keywords: sync, synchronize cases, pull, push, export, import, download, import.
+
+---
+
+## Testomat MCP Tool Policy
+
+This skill uses Testomat MCP only when MCP tools provide better precision than the `check-tests` CLI.
+
+### Allowed MCP Tools
+
+| Tool            | When to Use            |
+|-----------------|------------------------|
+| `tags_get`      | Get tests by tag title |
+| `tests_get`     | Get single test by ID (to verify or inspect) |
+| `tests_update`  | Update specific test attributes (priority, tags, labels) by ID |
+| `suites_get`    | Get suite info by ID |
+| `suites_update` | Update specific suite attributes (priority, tags, labels) by ID |
+| `labels_list`   | List available labels |
+| `labels_create` | Create a new label |
+| `labels_update` | Update existing label |
+
+### Use `check-tests` CLI (Default)
+
+- Bulk pull/push operations.
+- From-scratch sync.
+- Any operation without specific test IDs.
+- Directory-based import/export.
+
+### Use MCP Tools (Restricted)
+
+Only when user explicitly requests:
+- Update a **specific test** by ID (`tests_update`).
+- Change test **attributes** on existing tests (priority, tags, labels).
+- Search/get single test or suite by ID.
+
+### Blocking Rule
+
+If request involves "all tests", "bulk", "pull everything", "push all" => **prefer to use `check-tests` CLI** options, instead of MCP.
+
 ---
 
 ## Workflow: Sync Test Cases
@@ -123,14 +162,6 @@ labels: ...
 ... (test case description)
 
 ```
-
-#### Labels Handling (Intent-Based)
-
-- Use `TESTOMATIO_LABELS` **only if the user explicitly requests to set or override labels** in their query.
-- Example triggers:
-  - "push tests with labels smoke"
-  - "upload tests and set labels to regression,api"
-- Format: comma-separated values (supports `label:value` - `TESTOMATIO_LABELS="smoke,updated" npx check-tests push`).
 
 **Command:**
 ```bash

--- a/skills/sync-cases/SKILL.md
+++ b/skills/sync-cases/SKILL.md
@@ -154,9 +154,9 @@ npx check-tests push -d manual-tests
 
 **More examples** you can find in "Push" section [Testomat.io CLI Documentation](./references/TESTOMATIO_CLI.md)
 
-#### Verify Changes by Testomat MCP Tool (if enabled)
+### Verify Changes (if Testomat MCP tools enabled)
 
-Use MCP tools for checking and **updating existing test attributes**:
+Use MCP tools for checking and **updating existing test attributes** if no sync:
 
 | MCP Tool        | Use Case                                    |
 |----------------|---------------------------------------------|
@@ -166,11 +166,8 @@ Use MCP tools for checking and **updating existing test attributes**:
 | `labels_update` | Update existing label in test case |
 
 **Example workflow:**
-1. Pull tests: `npx check-tests pull -d folder`.
-2. Edit local `.test.md` files (update `priority:`, `labels:` in md metadata).
-3. Push updates => **use MCP** `tests_update` per test (not CLI push, which would rewrite everything).
-
-> If some suite/test metadata not synced - use Testomat MCP tool to save changes.
+1. Analyze a new/updated suite and tests only by local `.test.md` changes metadata (update `priority:`, `labels:` in md metadata).
+2. **use MCP** `tests_update` per test (not CLI push, which would rewrite everything).
 
 ---
 

--- a/skills/sync-cases/references/TESTOMATIO_CLI.md
+++ b/skills/sync-cases/references/TESTOMATIO_CLI.md
@@ -38,7 +38,6 @@ The tool supports loading environment variables from `.env` files using dotenv.
 | `TESTOMATIO_URL`         | Testomat.io server URL                                 | No (default: https://app.testomat.io) |
 | `TESTOMATIO_WORKDIR`     | Working directory for relative file paths              | No                                    |
 | `TESTOMATIO_PREPEND_DIR` | Directory to prepend to test paths                     | No                                    |
-| `TESTOMATIO_LABELS`      | Comma-separated labels. Supports `label:value`         | No                                    |
 
 ### Configuration File
 
@@ -121,9 +120,6 @@ npx check-tests push --no-empty
 
 # With prepend directory
 TESTOMATIO_PREPEND_DIR=backend-tests npx check-tests push
-
-# Apply labels to all imported tests
-TESTOMATIO_LABELS=smoke,updated npx check-tests push
 ```
 
 ---
@@ -134,5 +130,4 @@ TESTOMATIO_LABELS=smoke,updated npx check-tests push
 |--------|---------|
 | Pull tests | `npx check-tests pull -d <dir>` |
 | Push tests | `npx check-tests push -d <dir>` |
-| With labels | `TESTOMATIO_LABELS=smoke npx check-tests push` |
 | Keep structure | `npx check-tests pull --keep-structure` |


### PR DESCRIPTION
Add agent tool checking and MCP verification to sync-cases skill:
1. Added agent tool checking with clear error message to user when tools are disabled to skip a huge output
<img width="1555" height="614" alt="S-4-1" src="https://github.com/user-attachments/assets/09600159-ce43-48a6-8ddb-535c73a50f4a" />

2. Added MCP verification section for checking/updating test attributes after CLI sync:
<img width="1608" height="648" alt="S-5-2" src="https://github.com/user-attachments/assets/f5a9316d-4920-45dc-a475-098eba1326a8" />
<img width="1800" height="346" alt="S-5-3" src="https://github.com/user-attachments/assets/594ae282-3861-4833-b20c-cbc958d28090" />

2.1 Try to sync in MCP is disabled - no option to update 
<img width="1574" height="403" alt="S-5-4-no" src="https://github.com/user-attachments/assets/49bd0b30-94f6-4a8e-80df-e2e2dc1c74ea" />
