### PR TITLE
[SYNC CASES] Exclude unsupported option notes to sync-cases skill

### DIFF
--- a/skills/sync-cases/SKILL.md
+++ b/skills/sync-cases/SKILL.md
@@ -155,8 +155,9 @@ npx check-tests push -d manual-cases
 ```
 
 **Important constraints:**
-- Only use options that are explicitly documented in this skill or in the "Testomat.io CLI Documentation" ref file.
-- Do **not** assume support for undocumented options, like: `--pattern`, `--forces`, etc.
+- Only use options explicitly documented in this skill or in the "Testomat.io CLI Documentation" ref file.
+- If you are unsure about available CLI options, run `npx check-tests --help` and use only options listed there.
+- Do **not** use an option unless it is mentioned in the documentation or in the `--help` option (e.g., `--pattern`, `--forces`).
 
 **More examples** you can find in "Push" section [Testomat.io CLI Documentation](./references/TESTOMATIO_CLI.md)
 

--- a/skills/sync-cases/SKILL.md
+++ b/skills/sync-cases/SKILL.md
@@ -154,6 +154,10 @@ npx check-tests push
 npx check-tests push -d manual-cases
 ```
 
+**Important constraints:**
+- Only use options that are explicitly documented in this skill or in the "Testomat.io CLI Documentation" ref file.
+- Do **not** assume support for undocumented options, like: `--pattern`, `--forces`, etc.
+
 **More examples** you can find in "Push" section [Testomat.io CLI Documentation](./references/TESTOMATIO_CLI.md)
 
 #### Labels Handling (Intent-Based)
@@ -206,7 +210,7 @@ Stop execution if:
 
 | Description                  | File                                |
 | ---------------------------- | ----------------------------------- |
-| Testomat.io CLI Commands     | ./references/TESTOMATIO_CLI.md     |
+| Testomat.io CLI Commands     | ./references/TESTOMATIO_CLI.md      |
 
 ---
 


### PR DESCRIPTION
Additional skill improvements -> exclude unsupported option notes to `sync-cases` skill