### PR TITLE
[SCAN SKILL] Scan/Analyze/Discovery project source code for QA

### DIFF
--- a/plugins/test-management/skills/project-scan
+++ b/plugins/test-management/skills/project-scan
@@ -1,0 +1,1 @@
+../../../skills/project-scan

--- a/skills/project-scan/SKILL.md
+++ b/skills/project-scan/SKILL.md
@@ -15,15 +15,14 @@ Test Scanner Journey:
 - Analyze source code structure in project root.
 - Detect programming languages used.
 - Identify test frameworks (automated tests).
+  * Avoid deep parsing unit test and integration system files.
 - Inventory manual test cases from `.test.md` files.
 - Generate project scan JSON for test planning.
 
 **CONSTRAINT (large projects):**
-For large codebases, do not perform deep analysis:
-- Do not resolve full imports/dependencies.
-- Do not analyze code line-by-line.
-- Do not infer complex code relationships.
-Focus only on high-level structure.
+- Do not perform deep analysis: no full import resolution, no line‑by‑line parsing, no inference of complex code relationships. 
+
+**Focus only on high‑level structure**.
 
 ## When to Use
 
@@ -37,96 +36,67 @@ Trigger this skill when user wants to:
 
 ## Workflow: Scan Project (QA-Focused)
 
-### Step 1: Setup Context
+### Step 1: Understand Project Context
 
-Scan root dir and create `.testclaw-context/code/` **only if missing**:
+Scan root dir to understand which files we will analyze in the future:
 
-```bash
-mkdir -p .testclaw-context/code
+**Option-1** 
+- If folder includes NON empty source code folders, files => Go to "Step 2".
+
+**Option-2** 
+- If **no source** files are found in any of the listed directories, halt scanning and ask the user:
+
 ```
+❓ No application source code detected (folder may be empty or missing).
+Where is the source code?
+1. Use local project from another folder (I will create a symlink)
+2. Clone from Git repo
+3. I don't know yet (stop here)
+```
+[Waits for the user’s reply.]
+
+- If user provides `Git repo` or `another folder` variant => Check if cache directory `.testclaw-context/code` already exists. If not, create it and save files or symlink to this `code/` folder.
+*The command is a no‑op when the directory already exists.*
 
 ---
 
 ### Step 2: Project Analysis (Simplified)
 
-Scan user's project and collect:
+Scan the project and collect a list of **source code files only**.
 
-1. **Discover files** - Use the most appropriate method based on project context:
-- Prefer `git ls-files` if the project is a Git repository (respects `.gitignore`).
-- Otherwise, perform recursive file listing from project root.
+#### 1. Discover Files
 
-2. **Exclude non-source files and directories** - Apply the following exclusion rules:
-- **Dependency directories:** like `node_modules/`, `vendor/`, `.venv/`, `__pycache__/`.
-- **Build and generated artifacts:** like `dist/`, `build/`, `out/`, `target/`, `.next/`, `.cache/`, `.turbo/`.
-- **Coverage and reports:** `coverage/`, `reports/`.
-- **Lock and generated files:** like `*.lock`.
-- **Docker and Makefile files:** like `Dockerfile`.
-- **Ignored files:** Respect `.gitignore` if available.
-- **Configuration and env files:** like `.git/`, `.env`, `tsconfig.json`.
-- **TestClaw agent source files and prompts**: like `session-factory.ts`, `system-prompt.ts`
+- Traverse the project directory.
+- Collect file paths only (**Do NOT read file contents at this point**).
 
-**Skip these entirely during scanning.**
+#### 2. Filter to Source Code
+
+Include:
+- Application source files (e.g. `.js`, `.ts`, `.py`, `.java`, `.go`, etc.).
+
+Exclude:
+- Dependencies (e.g. `node_modules/`, `vendor/`, `.venv/`).
+- Build/generated output (e.g. `dist/`, `build/`, `.next/`, `target/`).
+- Coverage, reports, caches, config, lock, and environment files.
+- Ignored paths from `.gitignore`.
+- TestClaw internal files (e.g. `session-factory.ts`, `system-prompt.ts`).
 [**If in doubt**, prefer excluding over including non-source files.]
 
-// TODO: 3. **Detect Stack Technologies** — combine all code tech: source code, test frameworks, services, etc ????
-3. **Detect frameworks** — separate project and test frameworks:
+#### 3. Detect Tech Stack
 
-**PRIORITY: Project source code FIRST (mandatory), test frameworks SECOND (optional)**
+Infer program languages and frameworks from file extensions, structure, and config files. The result is a **single array** `frameworks` containing ALL observed application and testing frameworks.
 
-**A) Project Frameworks** (from source folders like app/, src/, backend/):
+#### 4. Extract Project Name
 
-| Config/Source | Framework |
-|----------------|------------|
-| `package.json` deps | React, Vue, Angular, Svelte, Next.js, Nuxt, Express, NestJS, Fastify, Koa |
-| `Cargo.toml` | Rust (actix, axum, rocket) |
-| `go.mod` | Go (gin, echo, fiber) |
-| `pyproject.toml` | Django, Flask, FastAPI |
-| `app/` folder | App code present |
-| `src/` folder | Source code present |
-| `backend/` folder | Backend structure |
-| `frontend/` folder | Frontend structure |
+- Use, in priority order:
+  1. Project config files (e.g. `package.json`, `Cargo.toml`).
+  2. Root directory name.
 
-**CRITICAL: Project source code MUST be accessible.**
+#### 5. Estimate Project Complexity
 
-Detect source via:
-- Directories: `app/`, `src/`, `backend/`, `frontend/`, `lib/`, `packages/`
-- MUST contain actual code files: `.ts`, `.js`, `.py`, `.go`, `.rs`, `.java`, `.html`, `.css`
+Based on total number of source files, choose one variant.
 
-**IMPORTANT:** 
-> `projectFrameworks` = application frameworks (MANDATORY if source exists AND has code files)
-- **`app/`, `src/`, `frontend/` with HTML/CSS only** (no framework deps) - `projectFrameworks: ["HTML", "CSS"]`
-- **If NO valid source files are found** in any of: `app/`, `src/`, `backend/`, `frontend/`, `lib/`, `packages/`
-=> STOP and Ask the user:
-
-// TODO: IF no source code / frameworks or empty folders detected -> ask user???
-
-```
-❓ No application source code detected (folder may be empty or missing).
-Where is the source code?
-
-- **1.** Use local project from another folder (I will create symlink)
-- **2.** Clone from Git repo
-- **3.** I don't know yet (STOP here)
-```
-[STOP and wait for user response].
-
-**Note:** Test files (playwright, vitest) are optional — project source comes FIRST.
-
-**B) Test Frameworks** (optional):
-
-| Config File | Test Framework |
-|-------------|-----------------|
-| `codecept.conf.js/ts` | CodeceptJS |
-| `playwright.config.ts` | Playwright |
-| `vitest.config.ts` | Vitest |
-| `jest.config.js` | Jest |
-| `pytest.ini`, `pyproject.toml` | pytest |
-
-> `testFrameworks` = testing tools (OPTIONAL)
-
-4. **Extract project name** from `package.json`, `Cargo.toml`, or directory name
-
-5. **Calculate complexity:**
+**Calculate complexity table:**
 
 | File Count | Complexity   |
 |------------|--------------|
@@ -135,33 +105,33 @@ Where is the source code?
 | 151-500    | `large`      |
 | 500+       | `very-large` |
 
-Output to `.testclaw-context/scan-result.json`:
+#### Output
+
+Save results to:
+- `scan-result.json` in the root directory if `.testclaw-context/` does NOT exist.
+- `.testclaw-context/scan-result.json`  if the cache folder already exists.
+
+**Example:**
 
 ```json
 {
   "name": "...",
   "description": "...",
-  "languages": ["typescript", "javascript"],
-  "projectFrameworks": ["..."], 
-  "testFrameworks": ["Playwright"],
+  "languages": ["javascript"],
+  "frameworks": ["..."],
   "estimatedComplexity": "small",
   "totalFiles": 12
 }
 ```
-TODO: don't split by projectFrameworks & testFrameworks - list as one array of all available frameworks in pne place
-- this should fix mandatory/optional confusing???
 
 [Field notes:
 * "name" - Project root folder name or repo name.
 * "description" - 1-2 sentence summary based ONLY on: detected source code and folder structure.
-* "projectFrameworks" - Application frameworks (mandatory, must be explicitly detected).
-* "testFrameworks" - Testing tools (optional, include only if present).
+* "frameworks" - Application frameworks, Testing tools, etc.
 * "estimatedComplexity" - One of: "small" | "moderate" | "large" | "very-large", based on file count + structure.
 * "totalFiles" - Total number of relevant source files]
 
 **Important:** 
-- `projectFrameworks` = app frameworks (MANDATORY).
-- `testFrameworks` = testing tools (OPTIONAL).
 - Do NOT guess or infer missing data.
 - Do NOT add fields not defined in the schema.
 - All values must come from observable files.
@@ -170,25 +140,23 @@ TODO: don't split by projectFrameworks & testFrameworks - list as one array of a
 
 ---
 
-### Step 4: Existing Tests Inventory
+### Step 3: Tests Inventory (optional)
 
-**A) Automated tests:**
+Detect existing tests (automated and manual).  
+This step is **shallow** - **Do NOT read full test implementations**.
 
-Detect test configs and count:
+### Automated Tests
 
-| Test Framework | Config File | Test Pattern |
-|---------------|------------|-------------|
-| CodeceptJS | `codecept.conf.js/ts` | `**/*.test.ts` |
-| Playwright | `playwright.config.ts` | `**/*.spec.ts` |
-| Vitest | `vitest.config.ts` | `**/*.test.ts` |
-| Jest | `jest.config.js` | `**/*.test.ts`, `**/*.spec.ts` |
-| pytest | `pytest.ini`, `pyproject.toml` | `**/*_test.py` |
-| Go | `*_test.go` files | `**/*_test.go` |
-| JUnit | `pom.xml`, `build.gradle` | `**/src/test/**` |
+Detect test automation frameworks using:
+- Config files (e.g. `jest.config.*`, `playwright.config.*`, `vitest.config.*`, `pytest.ini`, `pom.xml`, etc.).
+- Dependencies in project configs.
+- Common test file patterns (e.g. `*.test.*`, `*.spec.*`, `*_test.*`).
 
-Count files in each pattern.
+For each detected framework:
+- Identify test file patterns.
+- Count matching test files.
 
-**B) Manual tests:**
+### Manual Tests
 
 Find all `.test.md` files and parse test titles:
 
@@ -210,19 +178,18 @@ find . -name "*.test.md" -exec awk '
 
 ### Step 5: Final Output
 
-Merge all results into `.testclaw-context/scan-result.json`:
+Merge all results into previously created "scan-result" file (from "Step 2"):
 
 ```json
 {
   "name": "...",
   "description": "...",
-  "languages": ["typescript", "javascript"],
-  "projectFrameworks": ["React", "Vite"],
-  "testFrameworks": ["Playwright"],
-  "estimatedComplexity": "moderate",
-  "totalFiles": 42,
+  "languages": ["javascript"],
+  "frameworks": ["..."],
+  "estimatedComplexity": "small",
+  "totalFiles": 12,
   "testCounts": {
-    "automated": 25,
+    "automated": 20,
     "manual": 12
   },
   "manualTests": [
@@ -232,22 +199,17 @@ Merge all results into `.testclaw-context/scan-result.json`:
   ]
 }
 ```
-[Extra Field nNtes:
+
+[Extra Field Notes:
 * "testCounts" - Count only clearly identified tests (no guessing).
 * "manualTests" - Preserve hierarchy as plain strings (no restructuring)]
-
-**(This `scan-result.json` file must includes full list of available tests, if detect it)**
-
-**Important:** 
-- `projectFrameworks` = application frameworks (React, Vue, Express, Django, etc.)
-- `testFrameworks` = test tools (Playwright, Vitest, Jest, CodeceptJS, pytest, etc.)
 
 **Report a summary to the user:**
 * Provide a concise overview of the scan results (see example below).
 * Do not include full test listings.
 
 **Test listing constraint:**
-If manual/automated tests are included in output:
+If manual tests are included in output:
 - Limit displayed items to the first 25 entries.
 - Keep original file order.
 - Indicate truncation if more exist (e.g., `...and N more`).
@@ -259,12 +221,11 @@ If manual/automated tests are included in output:
 ```
 Scan Complete:
 - Project: ...
-- Languages: TypeScript
-- Project Frameworks: ... (mandatory)
-- Test Frameworks: Playwright (optional)
+- Languages: JavaScript
+- Frameworks: ...
 - Complexity: small (12 files)
-- Automated Tests: 2 files
-- Manual Tests: 9 cases
+- Automated Tests: 20 files
+- Manual Tests: 12 cases
 ```
 
 ---
@@ -304,15 +265,3 @@ What test frameworks exist in this project?
 ```
 List all automated and manual tests in this project
 ```
-
----
-
-## Quick Commands
-
-| Action            | Command                           |
-|-------------------|-----------------------------------|
-| Create context    | `mkdir -p .testclaw-context/code` |
-| Scan files        | `git ls-files` or `find . -type f -name "*.ts"` |
-| Find test configs | `find . -name "codecept.conf.*"` |
-| Find test files   | `find . -name "*.test.ts" -o -name "*.spec.ts"` |
-| Find manual tests | `find . -name "*.test.md"` |

--- a/skills/project-scan/SKILL.md
+++ b/skills/project-scan/SKILL.md
@@ -47,30 +47,7 @@ mkdir -p .testclaw-context/code
 
 ---
 
-### Step 2: Source Code Discovery
-
-**Check if current directory has source files** — detect via:
-- File extensions: `.ts`, `.js`, `.py`, `.go`, `.rs`, `.java`, `.cs`, etc.
-- Directories: `app/`, `src/`, `backend/`, `frontend/`, `lib/`, `packages/`, etc.
-
-**If test frameworks detected BUT no source folders found:**
-
-If `testFrameworks` is detected (Playwright, Vitest, etc.) but no source folders (`app/`, `src/`, `frontend/`) exist — ask user:
-
-```
-❓ This project has test automation (${testFramework}) but no application source detected.
-How should I proceed?
-
-- **1.** Use local app source from another folder (create symlink).
-- **2.** Clone app source from Git repo.  
-- **3.** Continue with test-only project.
-- **4.** Skip source code detecting.
-```
-[Wait for user input before proceeding].
-
----
-
-### Step 3: Project Analysis (Simplified)
+### Step 2: Project Analysis (Simplified)
 
 Scan user's project and collect:
 
@@ -83,17 +60,19 @@ Scan user's project and collect:
 - **Build and generated artifacts:** like `dist/`, `build/`, `out/`, `target/`, `.next/`, `.cache/`, `.turbo/`.
 - **Coverage and reports:** `coverage/`, `reports/`.
 - **Lock and generated files:** like `*.lock`.
+- **Docker and Makefile files:** like `Dockerfile`.
 - **Ignored files:** Respect `.gitignore` if available.
 - **Configuration and env files:** like `.git/`, `.env`, `tsconfig.json`.
+- **TestClaw agent source files and prompts**: like `session-factory.ts`, `system-prompt.ts`
 
 **Skip these entirely during scanning.**
 [**If in doubt**, prefer excluding over including non-source files.]
 
-3. **Detect frameworks** — separate application and test frameworks:
+3. **Detect frameworks** — separate project and test frameworks:
 
-**PRIORITY: Application frameworks first, then test frameworks.**
+**PRIORITY: Project source code FIRST (mandatory), test frameworks SECOND (optional)**
 
-**A) Application Frameworks** (from source code/configs):
+**A) Project Frameworks** (from source folders like app/, src/, backend/):
 
 | Config/Source | Framework |
 |----------------|------------|
@@ -101,13 +80,37 @@ Scan user's project and collect:
 | `Cargo.toml` | Rust (actix, axum, rocket) |
 | `go.mod` | Go (gin, echo, fiber) |
 | `pyproject.toml` | Django, Flask, FastAPI |
-| `app/` folder | As initial application folder |
+| `app/` folder | App code present |
 | `src/` folder | Source code present |
 | `backend/` folder | Backend structure |
 | `frontend/` folder | Frontend structure |
-[This table contains only basic examples and actual names may vary.]
 
-**B) Test Frameworks** (from test configs):
+**CRITICAL: Project source code MUST be accessible.**
+
+Detect source via:
+- Directories: `app/`, `src/`, `backend/`, `frontend/`, `lib/`, `packages/`
+- MUST contain actual code files: `.ts`, `.js`, `.py`, `.go`, `.rs`, `.java`, `.html`, `.css`
+
+**IMPORTANT:** 
+> `projectFrameworks` = application frameworks (MANDATORY if source exists AND has code files)
+- **`app/`, `src/`, `frontend/` with HTML/CSS only** (no framework deps) - `projectFrameworks: HTML/CSS (simple project)`
+- **If source folder exists BUT is empty OR has no code files** - STOP and ask user:
+- **If source folder like `app/`, `src/`, `frontend/` empty** - STOP and ask user:
+- **If source directories NOT found** - STOP and ask user:
+
+```
+❓ No application source code detected (folder may be empty or missing).
+Where is the source code?
+
+- **1.** Use local project from another folder (I will create symlink)
+- **2.** Clone from Git repo
+- **3.** I don't know yet (STOP here)
+```
+[STOP and wait for user response].
+
+**Note:** Test files (playwright, vitest) are optional — project source comes FIRST.
+
+**B) Test Frameworks** (optional):
 
 | Config File | Test Framework |
 |-------------|-----------------|
@@ -116,11 +119,8 @@ Scan user's project and collect:
 | `vitest.config.ts` | Vitest |
 | `jest.config.js` | Jest |
 | `pytest.ini`, `pyproject.toml` | pytest |
-| `*_test.go` | Go tests |
 
-**IMPORTANT:** 
-- List **application** frameworks in `frameworks` field.
-- List **test** frameworks in `testFrameworks` field.
+> `testFrameworks` = testing tools (OPTIONAL)
 
 4. **Extract project name** from `package.json`, `Cargo.toml`, or directory name
 
@@ -138,18 +138,18 @@ Output to `.testclaw-context/scan-result.json`:
 ```json
 {
   "name": "project-name",
-  "description": "...",
+  "description": "...",   // Based on the {projectFrameworks} info
   "languages": ["typescript", "javascript"],
-  "projectFrameworks": ["Vanilla JS"],        // Application frameworks or source folders
-  "testFrameworks": ["Playwright"],    // Test frameworks
+  "projectFrameworks": ["..."],  // Application frameworks (source folders) - (mandatory)
+  "testFrameworks": ["Playwright"],     // Test frameworks (optional)
   "estimatedComplexity": "small",
   "totalFiles": 12
 }
 ```
 
 **Important:** 
-- `frameworks` = app frameworks or source folders (Vanilla JS if app/ exists)
-- `testFrameworks` = testing tools (Playwright, Vitest, Jest, etc.)
+- `projectFrameworks` = app frameworks (MANDATORY)
+- `testFrameworks` = testing tools (OPTIONAL)
 
 **Show a summary** based on scan results.
 
@@ -200,9 +200,9 @@ Merge all results into `.testclaw-context/scan-result.json`:
 ```json
 {
   "name": "project-name",
-  "description": "...",
+  "description": "...",   // Based on the {projectFrameworks} info
   "languages": ["typescript", "javascript"],
-  "frameworks": ["React", "Vite"],        // Application frameworks
+  "projectFrameworks": ["React", "Vite"],        // Application frameworks (mandatory)
   "testFrameworks": ["Playwright"],     // Test frameworks (optional)
   "estimatedComplexity": "moderate",
   "totalFiles": 42,
@@ -220,7 +220,7 @@ Merge all results into `.testclaw-context/scan-result.json`:
 **(This `scan-result.json` file must includes full list of available tests)**
 
 **Important:** 
-- `frameworks` = application frameworks (React, Vue, Express, Django, etc.)
+- `projectFrameworks` = application frameworks (React, Vue, Express, Django, etc.)
 - `testFrameworks` = test tools (Playwright, Vitest, Jest, CodeceptJS, pytest, etc.)
 
 **Report a summary to the user:**
@@ -241,8 +241,8 @@ If manual/automated tests are included in output:
 Scan Complete:
 - Project: ...
 - Languages: TypeScript
-- Frameworks: Vanilla JS (from `app/` folder)
-- Test Frameworks: Playwright
+- Project Frameworks: ... (mandatory)
+- Test Frameworks: Playwright (optional)
 - Complexity: small (12 files)
 - Automated Tests: 2 files
 - Manual Tests: 9 cases

--- a/skills/project-scan/SKILL.md
+++ b/skills/project-scan/SKILL.md
@@ -93,10 +93,9 @@ Detect source via:
 
 **IMPORTANT:** 
 > `projectFrameworks` = application frameworks (MANDATORY if source exists AND has code files)
-- **`app/`, `src/`, `frontend/` with HTML/CSS only** (no framework deps) - `projectFrameworks: HTML/CSS (simple project)`
-- **If source folder exists BUT is empty OR has no code files** - STOP and ask user:
-- **If source folder like `app/`, `src/`, `frontend/` empty** - STOP and ask user:
-- **If source directories NOT found** - STOP and ask user:
+- **`app/`, `src/`, `frontend/` with HTML/CSS only** (no framework deps) - `projectFrameworks: ["HTML", "CSS"]`
+- **If NO valid source files are found** in any of: `app/`, `src/`, `backend/`, `frontend/`, `lib/`, `packages/`
+=> STOP and Ask the user:
 
 ```
 ❓ No application source code detected (folder may be empty or missing).
@@ -137,19 +136,30 @@ Output to `.testclaw-context/scan-result.json`:
 
 ```json
 {
-  "name": "project-name",
-  "description": "...",   // Based on the {projectFrameworks} info
+  "name": "...",
+  "description": "...",
   "languages": ["typescript", "javascript"],
-  "projectFrameworks": ["..."],  // Application frameworks (source folders) - (mandatory)
-  "testFrameworks": ["Playwright"],     // Test frameworks (optional)
+  "projectFrameworks": ["..."],
+  "testFrameworks": ["Playwright"],
   "estimatedComplexity": "small",
   "totalFiles": 12
 }
 ```
 
+[Field notes:
+* "name" - Project root folder name or repo name.
+* "description" - 1-2 sentence summary based ONLY on: detected source code and folder structure.
+* "projectFrameworks" - Application frameworks (mandatory, must be explicitly detected).
+* "testFrameworks" - Testing tools (optional, include only if present).
+* "estimatedComplexity" - One of: "small" | "moderate" | "large" | "very-large", based on file count + structure.
+* "totalFiles" - Total number of relevant source files]
+
 **Important:** 
-- `projectFrameworks` = app frameworks (MANDATORY)
-- `testFrameworks` = testing tools (OPTIONAL)
+- `projectFrameworks` = app frameworks (MANDATORY).
+- `testFrameworks` = testing tools (OPTIONAL).
+- Do NOT guess or infer missing data.
+- Do NOT add fields not defined in the schema.
+- All values must come from observable files.
 
 **Show a summary** based on scan results.
 
@@ -199,11 +209,11 @@ Merge all results into `.testclaw-context/scan-result.json`:
 
 ```json
 {
-  "name": "project-name",
-  "description": "...",   // Based on the {projectFrameworks} info
+  "name": "...",
+  "description": "...",
   "languages": ["typescript", "javascript"],
-  "projectFrameworks": ["React", "Vite"],        // Application frameworks (mandatory)
-  "testFrameworks": ["Playwright"],     // Test frameworks (optional)
+  "projectFrameworks": ["React", "Vite"],
+  "testFrameworks": ["Playwright"],
   "estimatedComplexity": "moderate",
   "totalFiles": 42,
   "testCounts": {
@@ -217,7 +227,11 @@ Merge all results into `.testclaw-context/scan-result.json`:
   ]
 }
 ```
-**(This `scan-result.json` file must includes full list of available tests)**
+[Extra Field nNtes:
+* "testCounts" - Count only clearly identified tests (no guessing).
+* "manualTests" - Preserve hierarchy as plain strings (no restructuring)]
+
+**(This `scan-result.json` file must includes full list of available tests, if detect it)**
 
 **Important:** 
 - `projectFrameworks` = application frameworks (React, Vue, Express, Django, etc.)

--- a/skills/project-scan/SKILL.md
+++ b/skills/project-scan/SKILL.md
@@ -53,12 +53,18 @@ mkdir -p .testclaw-context/code
 - File extensions: `.ts`, `.js`, `.py`, `.go`, `.rs`, `.java`, `.cs`, etc.
 - Directories: `app/`, `src/`, `backend/`, `frontend/`, `lib/`, `packages/`, etc.
 
-**If no source in root, ask user:**
+**If test frameworks detected BUT no source folders found:**
+
+If `testFrameworks` is detected (Playwright, Vitest, etc.) but no source folders (`app/`, `src/`, `frontend/`) exist — ask user:
 
 ```
-❓ What source code to use?
-- **1.** Local project from another folder (create symlink to `.testclaw-context/code/`)
-- **2.** Git repo (clone code to `.testclaw-context/code/`)
+❓ This project has test automation (${testFramework}) but no application source detected.
+How should I proceed?
+
+- **1.** Use local app source from another folder (create symlink).
+- **2.** Clone app source from Git repo.  
+- **3.** Continue with test-only project.
+- **4.** Skip source code detecting.
 ```
 [Wait for user input before proceeding].
 
@@ -90,15 +96,16 @@ Scan user's project and collect:
 **A) Application Frameworks** (from source code/configs):
 
 | Config/Source | Framework |
-|--------------|----------|
+|----------------|------------|
 | `package.json` deps | React, Vue, Angular, Svelte, Next.js, Nuxt, Express, NestJS, Fastify, Koa |
 | `Cargo.toml` | Rust (actix, axum, rocket) |
 | `go.mod` | Go (gin, echo, fiber) |
 | `pyproject.toml` | Django, Flask, FastAPI |
-| `app/` folder | Frontend app structure |
+| `app/` folder | As initial application folder |
 | `src/` folder | Source code present |
 | `backend/` folder | Backend structure |
 | `frontend/` folder | Frontend structure |
+[This table contains only basic examples and actual names may vary.]
 
 **B) Test Frameworks** (from test configs):
 
@@ -114,7 +121,6 @@ Scan user's project and collect:
 **IMPORTANT:** 
 - List **application** frameworks in `frameworks` field.
 - List **test** frameworks in `testFrameworks` field.
-- These are separate — a project can have both.
 
 4. **Extract project name** from `package.json`, `Cargo.toml`, or directory name
 
@@ -134,15 +140,15 @@ Output to `.testclaw-context/scan-result.json`:
   "name": "project-name",
   "description": "...",
   "languages": ["typescript", "javascript"],
-  "frameworks": ["React", "Vite"],        // Application frameworks FIRST
-  "testFrameworks": ["Playwright"],        // Test frameworks SECOND
-  "estimatedComplexity": "moderate",
-  "totalFiles": 42
+  "projectFrameworks": ["Vanilla JS"],        // Application frameworks or source folders
+  "testFrameworks": ["Playwright"],    // Test frameworks
+  "estimatedComplexity": "small",
+  "totalFiles": 12
 }
 ```
 
 **Important:** 
-- `frameworks` = application/frontend/backend frameworks
+- `frameworks` = app frameworks or source folders (Vanilla JS if app/ exists)
 - `testFrameworks` = testing tools (Playwright, Vitest, Jest, etc.)
 
 **Show a summary** based on scan results.
@@ -197,7 +203,7 @@ Merge all results into `.testclaw-context/scan-result.json`:
   "description": "...",
   "languages": ["typescript", "javascript"],
   "frameworks": ["React", "Vite"],        // Application frameworks
-  "testFrameworks": ["Playwright"],     // Test frameworks (separate)
+  "testFrameworks": ["Playwright"],     // Test frameworks (optional)
   "estimatedComplexity": "moderate",
   "totalFiles": 42,
   "testCounts": {
@@ -234,12 +240,12 @@ If manual/automated tests are included in output:
 ```
 Scan Complete:
 - Project: ...
-- Languages: TypeScript, JavaScript
-- Frameworks: (application structure from root, `app/`, etc)
+- Languages: TypeScript
+- Frameworks: Vanilla JS (from `app/` folder)
 - Test Frameworks: Playwright
-- Complexity: small (7 files)
-- Automated Tests: 3 files
-- Manual Tests: 0 cases
+- Complexity: small (12 files)
+- Automated Tests: 2 files
+- Manual Tests: 9 cases
 ```
 
 ---

--- a/skills/project-scan/SKILL.md
+++ b/skills/project-scan/SKILL.md
@@ -68,6 +68,7 @@ Scan user's project and collect:
 **Skip these entirely during scanning.**
 [**If in doubt**, prefer excluding over including non-source files.]
 
+// TODO: 3. **Detect Stack Technologies** — combine all code tech: source code, test frameworks, services, etc ????
 3. **Detect frameworks** — separate project and test frameworks:
 
 **PRIORITY: Project source code FIRST (mandatory), test frameworks SECOND (optional)**
@@ -96,6 +97,8 @@ Detect source via:
 - **`app/`, `src/`, `frontend/` with HTML/CSS only** (no framework deps) - `projectFrameworks: ["HTML", "CSS"]`
 - **If NO valid source files are found** in any of: `app/`, `src/`, `backend/`, `frontend/`, `lib/`, `packages/`
 => STOP and Ask the user:
+
+// TODO: IF no source code / frameworks or empty folders detected -> ask user???
 
 ```
 ❓ No application source code detected (folder may be empty or missing).
@@ -139,12 +142,14 @@ Output to `.testclaw-context/scan-result.json`:
   "name": "...",
   "description": "...",
   "languages": ["typescript", "javascript"],
-  "projectFrameworks": ["..."],
+  "projectFrameworks": ["..."], 
   "testFrameworks": ["Playwright"],
   "estimatedComplexity": "small",
   "totalFiles": 12
 }
 ```
+TODO: don't split by projectFrameworks & testFrameworks - list as one array of all available frameworks in pne place
+- this should fix mandatory/optional confusing???
 
 [Field notes:
 * "name" - Project root folder name or repo name.

--- a/skills/project-scan/SKILL.md
+++ b/skills/project-scan/SKILL.md
@@ -1,0 +1,293 @@
+---
+name: project-scan
+description: Scan project source code to inventory languages, frameworks, and existing tests (manual `*.test.md` and automated test files). Use this skill whenever analyzing codebase for test planning, detecting test frameworks, or preparing for test automation. Specifically, when user mentions "scan project", "what tests exist", "analyze codebase", "detect frameworks", "test matrix", or needs codebase inventory before QA workflow.
+license: MIT
+metadata:
+  author: Testomat.io
+  version: 1.0.0
+---
+
+# PROJECT-SCAN SKILL: What I do
+
+This skill scans project source code to produce a QA-focused inventory: languages, frameworks, and existing tests.
+
+Test Scanner Journey:
+- Analyze source code structure in project root.
+- Detect programming languages used.
+- Identify test frameworks (automated tests).
+- Inventory manual test cases from `.test.md` files.
+- Generate project scan JSON for test planning.
+
+**CONSTRAINT (large projects):**
+For large codebases, do not perform deep analysis:
+- Do not resolve full imports/dependencies.
+- Do not analyze code line-by-line.
+- Do not infer complex code relationships.
+Focus only on high-level structure.
+
+## When to Use
+
+Trigger this skill when user wants to:
+- **Scan/Analyze/Discovery** project source code for QA planning.
+- **Detect** what frameworks are used.
+- **Find** existing automated and manual tests in `.test.md` format.
+- **Inventory** codebase before testing procedures.
+
+---
+
+## Workflow: Scan Project (QA-Focused)
+
+### Step 1: Setup Context
+
+Scan root dir and create `.testclaw-context/code/` **only if missing**:
+
+```bash
+mkdir -p .testclaw-context/code
+```
+
+---
+
+### Step 2: Source Code Discovery
+
+**Check if current directory has source files** — detect via:
+- File extensions: `.ts`, `.js`, `.py`, `.go`, `.rs`, `.java`, `.cs`, etc.
+- Directories: `app/`, `src/`, `backend/`, `frontend/`, `lib/`, `packages/`, etc.
+
+**If no source in root, ask user:**
+
+```
+❓ What source code to use?
+- **1.** Local project from another folder (create symlink to `.testclaw-context/code/`)
+- **2.** Git repo (clone code to `.testclaw-context/code/`)
+```
+[Wait for user input before proceeding].
+
+---
+
+### Step 3: Project Analysis (Simplified)
+
+Scan user's project and collect:
+
+1. **Discover files** - Use the most appropriate method based on project context:
+- Prefer `git ls-files` if the project is a Git repository (respects `.gitignore`).
+- Otherwise, perform recursive file listing from project root.
+
+2. **Exclude non-source files and directories** - Apply the following exclusion rules:
+- **Dependency directories:** like `node_modules/`, `vendor/`, `.venv/`, `__pycache__/`.
+- **Build and generated artifacts:** like `dist/`, `build/`, `out/`, `target/`, `.next/`, `.cache/`, `.turbo/`.
+- **Coverage and reports:** `coverage/`, `reports/`.
+- **Lock and generated files:** like `*.lock`.
+- **Ignored files:** Respect `.gitignore` if available.
+- **Configuration and env files:** like `.git/`, `.env`, `tsconfig.json`.
+
+**Skip these entirely during scanning.**
+[**If in doubt**, prefer excluding over including non-source files.]
+
+3. **Detect frameworks** — separate application and test frameworks:
+
+**PRIORITY: Application frameworks first, then test frameworks.**
+
+**A) Application Frameworks** (from source code/configs):
+
+| Config/Source | Framework |
+|--------------|----------|
+| `package.json` deps | React, Vue, Angular, Svelte, Next.js, Nuxt, Express, NestJS, Fastify, Koa |
+| `Cargo.toml` | Rust (actix, axum, rocket) |
+| `go.mod` | Go (gin, echo, fiber) |
+| `pyproject.toml` | Django, Flask, FastAPI |
+| `app/` folder | Frontend app structure |
+| `src/` folder | Source code present |
+| `backend/` folder | Backend structure |
+| `frontend/` folder | Frontend structure |
+
+**B) Test Frameworks** (from test configs):
+
+| Config File | Test Framework |
+|-------------|-----------------|
+| `codecept.conf.js/ts` | CodeceptJS |
+| `playwright.config.ts` | Playwright |
+| `vitest.config.ts` | Vitest |
+| `jest.config.js` | Jest |
+| `pytest.ini`, `pyproject.toml` | pytest |
+| `*_test.go` | Go tests |
+
+**IMPORTANT:** 
+- List **application** frameworks in `frameworks` field.
+- List **test** frameworks in `testFrameworks` field.
+- These are separate — a project can have both.
+
+4. **Extract project name** from `package.json`, `Cargo.toml`, or directory name
+
+5. **Calculate complexity:**
+
+| File Count | Complexity   |
+|------------|--------------|
+| 1-30       | `small`      |
+| 31-150     | `moderate`   |
+| 151-500    | `large`      |
+| 500+       | `very-large` |
+
+Output to `.testclaw-context/scan-result.json`:
+
+```json
+{
+  "name": "project-name",
+  "description": "...",
+  "languages": ["typescript", "javascript"],
+  "frameworks": ["React", "Vite"],        // Application frameworks FIRST
+  "testFrameworks": ["Playwright"],        // Test frameworks SECOND
+  "estimatedComplexity": "moderate",
+  "totalFiles": 42
+}
+```
+
+**Important:** 
+- `frameworks` = application/frontend/backend frameworks
+- `testFrameworks` = testing tools (Playwright, Vitest, Jest, etc.)
+
+**Show a summary** based on scan results.
+
+---
+
+### Step 4: Existing Tests Inventory
+
+**A) Automated tests:**
+
+Detect test configs and count:
+
+| Test Framework | Config File | Test Pattern |
+|---------------|------------|-------------|
+| CodeceptJS | `codecept.conf.js/ts` | `**/*.test.ts` |
+| Playwright | `playwright.config.ts` | `**/*.spec.ts` |
+| Vitest | `vitest.config.ts` | `**/*.test.ts` |
+| Jest | `jest.config.js` | `**/*.test.ts`, `**/*.spec.ts` |
+| pytest | `pytest.ini`, `pyproject.toml` | `**/*_test.py` |
+| Go | `*_test.go` files | `**/*_test.go` |
+| JUnit | `pom.xml`, `build.gradle` | `**/src/test/**` |
+
+Count files in each pattern.
+
+**B) Manual tests:**
+
+Find all `.test.md` files and parse test titles:
+
+```bash
+find . -name "*.test.md" -exec awk '
+  /^<!-- test/   { in_block=1; kind="TEST";  next }
+  /^<!-- suite/  { in_block=1; kind="SUITE"; next }
+  in_block && /^-->/ { in_block=0; expect=1; next }
+  expect && /^#+[[:space:]]+/ {
+    title=$0; sub(/^#+[[:space:]]+/, "", title)
+    if (kind == "SUITE") printf "SUITE: %s\n", title
+    else             printf "|- %s\n",     title
+    expect=0
+  }
+' {} +
+```
+
+---
+
+### Step 5: Final Output
+
+Merge all results into `.testclaw-context/scan-result.json`:
+
+```json
+{
+  "name": "project-name",
+  "description": "...",
+  "languages": ["typescript", "javascript"],
+  "frameworks": ["React", "Vite"],        // Application frameworks
+  "testFrameworks": ["Playwright"],     // Test frameworks (separate)
+  "estimatedComplexity": "moderate",
+  "totalFiles": 42,
+  "testCounts": {
+    "automated": 25,
+    "manual": 12
+  },
+  "manualTests": [
+    "SUITE: Authentication",
+    "|- User can login",
+    "|- User can reset password"
+  ]
+}
+```
+**(This `scan-result.json` file must includes full list of available tests)**
+
+**Important:** 
+- `frameworks` = application frameworks (React, Vue, Express, Django, etc.)
+- `testFrameworks` = test tools (Playwright, Vitest, Jest, CodeceptJS, pytest, etc.)
+
+**Report a summary to the user:**
+* Provide a concise overview of the scan results (see example below).
+* Do not include full test listings.
+
+**Test listing constraint:**
+If manual/automated tests are included in output:
+- Limit displayed items to the first 25 entries.
+- Keep original file order.
+- Indicate truncation if more exist (e.g., `...and N more`).
+
+---
+
+## Final Summary Example
+
+```
+Scan Complete:
+- Project: ...
+- Languages: TypeScript, JavaScript
+- Frameworks: (application structure from root, `app/`, etc)
+- Test Frameworks: Playwright
+- Complexity: small (7 files)
+- Automated Tests: 3 files
+- Manual Tests: 0 cases
+```
+
+---
+
+## Error Handling
+
+### Recovery
+
+Attempt recovery before failing:
+
+- **Symlink exists** => skip, use existing path.
+- **No source found** => wait for user response.
+- **Scanner fails** => fallback to simple file listing.
+
+### Hard Fail
+
+Stop if:
+- Cannot create context directory
+- Cannot access source path
+- No read permissions
+
+---
+
+## Examples
+
+**Scan project:**
+```
+Use project-scan to analyze this codebase for test planning
+```
+
+**Find test frameworks:**
+```
+What test frameworks exist in this project?
+```
+
+**Get test inventory:**
+```
+List all automated and manual tests in this project
+```
+
+---
+
+## Quick Commands
+
+| Action            | Command                           |
+|-------------------|-----------------------------------|
+| Create context    | `mkdir -p .testclaw-context/code` |
+| Scan files        | `git ls-files` or `find . -type f -name "*.ts"` |
+| Find test configs | `find . -name "codecept.conf.*"` |
+| Find test files   | `find . -name "*.test.ts" -o -name "*.spec.ts"` |
+| Find manual tests | `find . -name "*.test.md"` |

--- a/skills/project-scan/SKILL.md
+++ b/skills/project-scan/SKILL.md
@@ -123,7 +123,7 @@ Use the following markdown format:
 
 [Field notes:
 * **Project Name** - Project root folder name or repo name.
-* **Description** - 1-2 sentence summary based ONLY on: detected source code and folder structure.
+* **Description** - 1-2 sentence summary based ONLY on: detected source code and folder structure (including domain area if that make sense for current project).
 * **Languages** - Detected programming languages.
 * **Frameworks** - Application frameworks, Testing tools, etc.
 * **Complexity** - One of: `small` | `moderate` | `large` | `very-large`, based on file count + structure.]

--- a/skills/project-scan/SKILL.md
+++ b/skills/project-scan/SKILL.md
@@ -17,12 +17,11 @@ Test Scanner Journey:
 - Identify test frameworks (automated tests).
   * Avoid deep parsing unit test and integration system files.
 - Inventory manual test cases from `.test.md` files.
-- Generate project scan JSON for test planning.
 
 **CONSTRAINT (large projects):**
-- Do not perform deep analysis: no full import resolution, no line‑by‑line parsing, no inference of complex code relationships. 
+- Do not perform deep analysis: no full import resolution, no line-by-line parsing, no inference of complex code relationships.
 
-**Focus only on high‑level structure**.
+**Focus only on high-level structure**.
 
 ## When to Use
 
@@ -40,11 +39,11 @@ Trigger this skill when user wants to:
 
 Scan root dir to understand which files we will analyze in the future:
 
-**Option-1** 
-- If folder includes NON empty source code folders, files => Go to "Step 2".
+**Option-1**
+- If folder includes non-empty source code folders or files => Go to "Step 2".
 
-**Option-2** 
-- If **no source** files are found in any of the listed directories, halt scanning and ask the user:
+**Option-2**
+- If **no source** files are found in any of the listed directories, stop scanning and ask the user:
 
 ```
 ❓ No application source code detected (folder may be empty or missing).
@@ -53,10 +52,10 @@ Where is the source code?
 2. Clone from Git repo
 3. I don't know yet (stop here)
 ```
-[Waits for the user’s reply.]
+[Waits for the user's reply.]
 
 - If user provides `Git repo` or `another folder` variant => Check if cache directory `.testclaw-context/code` already exists. If not, create it and save files or symlink to this `code/` folder.
-*The command is a no‑op when the directory already exists.*
+*The command is a no-op when the directory already exists.*
 
 ---
 
@@ -89,7 +88,7 @@ Infer program languages and frameworks from file extensions, structure, and conf
 #### 4. Extract Project Name
 
 - Use, in priority order:
-  1. Project config files (e.g. `package.json`, `Cargo.toml`).
+  1. Project config files (e.g. `package.json`, `Cargo.toml`, `pom.xml`).
   2. Root directory name.
 
 #### 5. Estimate Project Complexity
@@ -105,33 +104,31 @@ Based on total number of source files, choose one variant.
 | 151-500    | `large`      |
 | 500+       | `very-large` |
 
-#### Output
+#### Output (Structured Result)
 
-Save results to:
-- `scan-result.json` in the root directory if `.testclaw-context/` does NOT exist.
-- `.testclaw-context/scan-result.json`  if the cache folder already exists.
+Produce and return a single structured markdown result directly. 
+**Do NOT save to a file.** 
 
-**Example:**
+Use the following markdown format:
 
-```json
-{
-  "name": "...",
-  "description": "...",
-  "languages": ["javascript"],
-  "frameworks": ["..."],
-  "estimatedComplexity": "small",
-  "totalFiles": 12
-}
+```markdown
+# Project Overview
+
+- **Project Name:** ...
+- **Description:** ...
+- **Languages:** TypeScript, SQL
+- **Frameworks:** React, Express, Jest, Playwright
+- **Complexity:** small (12 files)
 ```
 
 [Field notes:
-* "name" - Project root folder name or repo name.
-* "description" - 1-2 sentence summary based ONLY on: detected source code and folder structure.
-* "frameworks" - Application frameworks, Testing tools, etc.
-* "estimatedComplexity" - One of: "small" | "moderate" | "large" | "very-large", based on file count + structure.
-* "totalFiles" - Total number of relevant source files]
+* **Project Name** - Project root folder name or repo name.
+* **Description** - 1-2 sentence summary based ONLY on: detected source code and folder structure.
+* **Languages** - Detected programming languages.
+* **Frameworks** - Application frameworks, Testing tools, etc.
+* **Complexity** - One of: `small` | `moderate` | `large` | `very-large`, based on file count + structure.]
 
-**Important:** 
+**Important:**
 - Do NOT guess or infer missing data.
 - Do NOT add fields not defined in the schema.
 - All values must come from observable files.
@@ -142,7 +139,7 @@ Save results to:
 
 ### Step 3: Tests Inventory (optional)
 
-Detect existing tests (automated and manual).  
+Detect existing tests (automated and manual).
 This step is **shallow** - **Do NOT read full test implementations**.
 
 ### Automated Tests
@@ -178,55 +175,55 @@ find . -name "*.test.md" -exec awk '
 
 ### Step 5: Final Output
 
-Merge all results into previously created "scan-result" file (from "Step 2"):
+Merge all results into the structured markdown format.
 
-```json
-{
-  "name": "...",
-  "description": "...",
-  "languages": ["javascript"],
-  "frameworks": ["..."],
-  "estimatedComplexity": "small",
-  "totalFiles": 12,
-  "testCounts": {
-    "automated": 20,
-    "manual": 12
-  },
-  "manualTests": [
-    "SUITE: Authentication",
-    "|- User can login",
-    "|- User can reset password"
-  ]
-}
+- If **no tests are found**, return a note that the current version of the project does not contain any tests. The user may still use the `## Project Overview` section above for next steps.
+- If **tests were inventoried**, append a `## Test Inventory` section.
+
+**Full example:**
+
+```markdown
+# Project Overview
+
+- **Project Name:** ...
+- **Description:** ...
+- **Languages:** TypeScript, SQL
+- **Frameworks:** React, Express, Jest, Playwright
+- **Complexity:** small (12 files)
+
+## Test Inventory
+
+- **Automated Tests:** 10 files
+- **Manual Tests:** 37 cases
+
+### Manual Tests (25 of 37 shown)
+
+- SUITE: Authentication
+  |- User can login
+  |- User can reset password
+- SUITE: Billing
+  |- User can view invoice
+  ...and 9 more
+
+### Automated Tests (10 of 10 shown)
+
+- home.page.spec.ts
+...
 ```
 
 [Extra Field Notes:
-* "testCounts" - Count only clearly identified tests (no guessing).
-* "manualTests" - Preserve hierarchy as plain strings (no restructuring)]
+* **Manual Tests** — Preserve hierarchy as plain strings. Render SUITE items as parent bullets and test titles (`|-`) as nested children.]
+* **Automated Tests** — List of identified test files.
 
 **Report a summary to the user:**
 * Provide a concise overview of the scan results (see example below).
 * Do not include full test listings.
 
 **Test listing constraint:**
-If manual tests are included in output:
-- Limit displayed items to the first 25 entries.
+If manual / automated tests are included in output:
+- Limit displayed items to the first 20 entries.
 - Keep original file order.
 - Indicate truncation if more exist (e.g., `...and N more`).
-
----
-
-## Final Summary Example
-
-```
-Scan Complete:
-- Project: ...
-- Languages: JavaScript
-- Frameworks: ...
-- Complexity: small (12 files)
-- Automated Tests: 20 files
-- Manual Tests: 12 cases
-```
 
 ---
 
@@ -251,17 +248,61 @@ Stop if:
 
 ## Examples
 
-**Scan project:**
-```
-Use project-scan to analyze this codebase for test planning
+### Example: Scan Project
+
+User Prompt: `Use project-scan to analyze this project codebase`
+Skill Output:
+
+```markdown
+# Project Overview
+
+- **Project Name:** acme-web-app
+- **Description:** A React-based customer dashboard. Uses TypeScript for the frontend and Express for the API.
+- **Languages:** TypeScript, JavaScript
+- **Frameworks:** React, Express, Jest
+- **Complexity:** moderate (87 files)
+
+## Test Inventory
+
+- **Automated Tests:** 24 files
+- **Manual Tests:** 0 cases
+
+> No manual tests (`.test.md`) found in the project.
+
+### Automated Tests (20 of 24 shown)
+
+- home.page.spec.ts
+...
 ```
 
-**Find test frameworks:**
-```
-What test frameworks exist in this project?
+### Example: Get Test Inventory
+
+User Prompt: `List all automated and manual tests in this project`
+Skill Output:
+
+```markdown
+# Project Overview
+
+- **Project Name:** acme-web-app
+- **Description:** A React-based customer dashboard.
+- **Languages:** TypeScript
+- **Frameworks:** React, Playwright, Jest
+- **Complexity:** moderate (87 files)
+
+## Test Inventory
+
+- **Automated Tests:** 0 files
+- **Manual Tests:** 37 cases
+
+### Manual Tests (20 of 37 shown)
+
+- SUITE: Authentication
+  |- User can login
+  |- User can reset password
+- SUITE: Billing
+  |- User can view invoice
+  ...and 34 more
+
+> No automation tests found in the project.
 ```
 
-**Get test inventory:**
-```
-List all automated and manual tests in this project
-```


### PR DESCRIPTION
Based on our discussions, I crafted a new skill for Scan/Analyze/Discovery project source code for QA actions.
Covered:
- Project Frameworks detecting
- Test Framework detecting
- Output to `.testclaw-context/scan-result.json` all discovered info

The main questions are:
- how to scan source code in "testclaw setup"? Do we need to solve this case?
- if we have test framework, code framework, third-part services code in one place - source code is mandatory for scanning?
- 