### PR TITLE
Add explorbot plugin (setup, fundamentals, plan skills)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -16,6 +16,11 @@
       "name": "test-automation",
       "source": "./plugins/test-automation",
       "description": "Adds a /test-automation skill for test automation (create, heal, sync results, etc)"
+    },
+    {
+      "name": "explorbot",
+      "source": "./plugins/explorbot",
+      "description": "Adds /explorbot-setup, /explorbot-fundamentals and /explorbot-plan skills to install, configure, run, debug and plan Explorbot autonomous AI web tests"
     }
   ]
 }

--- a/README.md
+++ b/README.md
@@ -40,6 +40,14 @@ For other ways of installation (Claude Code plugin, Codex, Cursor etc.) see [ins
 | ---------------- | ---------------------------------------------------------------------------------------------------- |
 | `reporter-setup` | Set up Testomat.io test reporting for your automation framework (Playwright, CodeceptJS, Jest, etc.) |
 
+### Explorbot
+
+| Skill                    | Description                                                                          |
+| ------------------------ | ------------------------------------------------------------------------------------ |
+| `explorbot-setup`        | First-time install & configuration of Explorbot, including initial knowledge          |
+| `explorbot-fundamentals` | Operating reference: run, drive and debug all Explorbot commands, config and outputs   |
+| `explorbot-plan`         | Author an Explorbot test plan in markdown so `explorbot test` can run it               |
+
 ---
 
 ## Repository Structure
@@ -58,6 +66,9 @@ testomatio/skills
     │   └── skills/
     │       └── [symlinks to ../../skills/*]
     ├── test-automation/
+    │   └── skills/
+    │       └── [symlinks to ../../skills/*]
+    ├── explorbot/
     │   └── skills/
     │       └── [symlinks to ../../skills/*]
     └── ...

--- a/plugins/explorbot/.claude-plugin/plugin.json
+++ b/plugins/explorbot/.claude-plugin/plugin.json
@@ -1,0 +1,8 @@
+{
+  "name": "explorbot",
+  "description": "Install, configure, run, debug and plan Explorbot autonomous AI web tests",
+  "version": "0.0.1",
+  "author": {
+    "name": "Testomat.io"
+  }
+}

--- a/plugins/explorbot/skills/explorbot-fundamentals
+++ b/plugins/explorbot/skills/explorbot-fundamentals
@@ -1,0 +1,1 @@
+../../../skills/explorbot-fundamentals

--- a/plugins/explorbot/skills/explorbot-plan
+++ b/plugins/explorbot/skills/explorbot-plan
@@ -1,0 +1,1 @@
+../../../skills/explorbot-plan

--- a/plugins/explorbot/skills/explorbot-setup
+++ b/plugins/explorbot/skills/explorbot-setup
@@ -1,0 +1,1 @@
+../../../skills/explorbot-setup

--- a/skills/explorbot-fundamentals/SKILL.md
+++ b/skills/explorbot-fundamentals/SKILL.md
@@ -1,0 +1,164 @@
+---
+name: explorbot-fundamentals
+description: Core operating reference for Explorbot — the autonomous AI web-testing CLI. Use this skill whenever the user runs or debugs Explorbot via the command line: choosing freesail/explore/test, any `explorbot` CLI command or flag, config sections, knowledge/rules/experience, the output/ artifacts, reporting, secure credentials, providers, or troubleshooting a failing run. Guide-only — present the exact commands/paths/config; the user runs them. For first-time install/config use `explorbot-setup`.
+license: MIT
+metadata:
+  author: Testomat.io
+  version: 0.0.1
+---
+
+# EXPLORBOT-FUNDAMENTALS: What I do
+
+Explorbot explores a web app like a curious human — clicking, filling forms, finding bugs,
+learning — with no test scripts. It drives its own browser via CodeceptJS → Playwright (no
+MCP). Workflow: **research → plan → test → repeat**. It learns from experience and from the
+knowledge you give it.
+
+This skill is the operating reference: how to run and **debug** Explorbot from the command
+line, what each config/dir/output does, and where to read deeper docs. **Guide-only** —
+present commands and config; the user runs them. Do not edit files or run commands unless
+explicitly asked.
+
+## Execution mode: CLI only
+
+**A coding agent can run Explorbot only through its non-interactive CLI commands** (e.g.
+`explorbot explore`, `explorbot test`, `explorbot plan`, `explorbot research`). These run
+headless and exit.
+
+**`explorbot start` launches the interactive terminal UI (TUI). An agent cannot drive a
+TUI — never attempt to launch or operate it.** TUI slash commands (`/explore`, `/plan`,
+`/test`, `I.click(...)`, …) are for a human at the keyboard. If the user wants interactive
+mode, tell them to run `explorbot start [path]` themselves; everything an agent does for them
+uses the CLI equivalents below.
+
+Before anything: check `explorbot.config.{js,mjs,ts}` exists (also `config/`, `src/config/`).
+If none exists and the user wants to set up, defer to the **`explorbot-setup`** skill.
+
+## Main testing flows — widest to narrowest
+
+| Flow | Command | Scope | Notes |
+| --- | --- | --- | --- |
+| **freesail** | `explorbot freesail <path> --max-tests N` | Whole app, page by page, continuously | `--max-tests` required (it never stops on its own). `--deep` depth-first, `--shallow` breadth-first, `--scope /admin` to fence it |
+| **explore** | `explorbot explore /page --max-tests N` | One area + its subpages: research → plan → test → exit | `--max-tests` required. `--focus <feature>`, `--dry-run`, `--configure` to reuse/mix plans |
+| **test** | `explorbot test plan.md 1` | A single scenario from a plan | Narrowest. Author the plan with the `explorbot-plan` skill |
+
+Pick the widest flow the user actually wants: freesail for unattended coverage, explore for a
+section, test for one scenario. Always set `--max-tests` for freesail and explore.
+
+`--configure` spec (semicolon pairs):
+`new:0%-100%;from:<plan>;style:normal,psycho,curious;priority:critical,high;pick_by:priority|random|index;subpages:none|same|new|both`.
+`explorbot test` index syntax: `1`, `1-5`, `1,3,7`, `*`/`all`, `"pattern"`.
+
+## Other CLI commands
+
+| Command | Purpose |
+| --- | --- |
+| `explorbot plan <path> [feature]` | Generate a test plan (AI explores the live page) |
+| `explorbot plan:load <file> [i]` | Load a plan and list its tests (no run) |
+| `explorbot research <url>` | Analyze a page, print the UI map |
+| `explorbot drill <url>` | Drill components to learn interactions |
+| `explorbot context <url>` | Print page snapshot (HTML/ARIA/data) |
+| `explorbot learn [url] [desc]` | Add knowledge |
+| `explorbot knows [url]` | List/show knowledge |
+| `explorbot experience [filter] [i]` | Inspect learned experience |
+| `explorbot rerun <file> [i]` | Re-run generated tests with AI healing |
+| `explorbot runs [file]` | List generated tests / dry-run a file |
+| `explorbot extract-rules <agent>` | Scaffold editable agent rules / planner styles |
+| `explorbot browser start\|stop\|status` | Manage a persistent browser server |
+
+Common flags (all CLI): `-v, --verbose` / `--debug`, `-c, --config <path>`,
+`-p, --path <dir>`, `-s, --show` / `--headless`, `--incognito` (no experience),
+`--session [file]` (persist cookies/localStorage; default `output/session.json`).
+
+## Credentials & secrets — never hardcode
+
+All secrets load from the environment (`.env` or the shell), never literals in config or
+knowledge:
+
+| Secret | How |
+| --- | --- |
+| AI provider API key | `.env` (`OPENROUTER_API_KEY` / `OPENAI_API_KEY` / `ANTHROPIC_API_KEY` / `GROQ_API_KEY` / `CEREBRAS_API_KEY`); referenced as `process.env.X` in `explorbot.config.js` |
+| App / user login | Knowledge file body using `${env.USER}` / `${env.PASSWORD}`; real values in `.env`. Or `--session` to log in once and reuse cookies |
+| Testomat.io | `TESTOMATIO=<key>` env (plus `TESTOMATIO_TITLE/_ENV/_SHARED_RUN/_RUNGROUP_TITLE`) |
+| Langfuse | `.env` `LANGFUSE_PUBLIC_KEY` / `LANGFUSE_SECRET_KEY` (`LANGFUSE_BASE_URL` if self-hosted) |
+
+Confirm `.env` is git-ignored. In knowledge/config interpolate `${env.X}` / `${config.a.b}`;
+do not paste raw credentials.
+
+## Teaching Explorbot — knowledge, rules, experience
+
+| Dir | Who writes | What |
+| --- | --- | --- |
+| `./knowledge/` | You | Credentials, form rules, nav quirks. MD + YAML frontmatter: `url:` (pattern: `/exact`, `/path/*`, `*`, `^regex$`, `~contains`), `wait:`, `waitForElement:`, `code:` (CodeceptJS, `await tryTo/retryTo/within`), `statePush:`. Interpolate `${env.X}`, `${config.a.b}`. Add via `explorbot learn`. See `docs/knowledge.md` |
+| `./rules/<agent>/` | You | Per-agent instructions; `rules/planner/styles/*.md` planning styles. Wire via `ai.agents.<a>.rules: ['name', {'/path/*':'name'}]`. Scaffold: `explorbot extract-rules <agent>`. See `docs/configuration.md` |
+| `./experience/` | Explorbot | Memory layer - Auto-saved working locators/flows (FLOW/ACTION blocks + `related:` URLs). Inspect via `explorbot experience` |
+
+Planning styles cycle `normal → psycho → curious` (outcome strength: data-change >
+state-change > UI-only). Reorder via `ai.agents.planner.styles`; add custom styles under
+`rules/planner/styles/`. See `docs/planner.md`.
+
+## output/ — what you get
+
+| Path | Contents |
+| --- | --- |
+| `output/explorbot.log` | **Always-on activity log — start debugging here** |
+| `output/plans/*.md` | Generated test plans |
+| `output/tests/*.spec.ts` \| `*.js` | Runnable Playwright / CodeceptJS tests (commit to CI) |
+| `output/reports/<mode>-<session>.html` | HTML report (always created) |
+| `output/reports/<mode>-<session>.md` | Analyst session report (defects clustered by root cause) |
+| `output/reports/<mode>-<session>-tests.md` | Per-test markdown (when `reporter.markdown`) |
+| `output/research/<hash>.{html,aria.yaml,png}` | What Researcher saw |
+| `output/states/`, `states/rerun_<ts>/` | Per-step snapshots; rerun `trace.md` + aria/html/png/console |
+| `output/screencasts/*.webm` | Per-scenario video (when `historian.screencast`) |
+| `output/requests/` | API request/response logs |
+| `output/session.json` | Saved cookies/localStorage for `--session` |
+
+Dirs relocatable via `dirs: { knowledge, experience, output }`.
+
+## Reporting & generated code
+
+- HTML report and the Analyst markdown are written every run under `output/reports/`.
+- **Recommended:** `reporter: { enabled: true, html: true, markdown: true }` → adds per-test
+  `…-tests.md`.
+- Runnable code: `ai.agents.historian.framework: 'playwright' | 'codeceptjs'` →
+  `output/tests/`. **Recommended:** `ai.agents.historian.screencast: true` (or
+  `{ size, quality }`) → `.webm` per scenario.
+- Testomat.io cloud via `TESTOMATIO` env or `reporter.enabled`; group with
+  `reporter.runGroup`. See `docs/reporting.md`. Rerun/healing tuning:
+  `ai.agents.rerunner.{healLimit,healMaxIterations,recipes}`, `docs/rerun.md`.
+- API testing: `api: { baseEndpoint, spec, headers, bootstrap, teardown }`;
+  `explorbot api plan|test|explore`. See `docs/api-testing.md`.
+
+## Troubleshooting — work the ladder in order
+
+**1 · Check the basics first.**
+- Playwright browsers installed (`npx playwright install`).
+- Target site reachable from this machine (try the URL in a normal browser).
+- AI reachable: provider key set in `.env`, model resolves. The error
+  `AI model is not configured. Set ai.model in your config file.` means key/model missing;
+  `Missing required configuration: web.url or playwright.url` means no base URL;
+  `No configuration file found...` → run `explorbot-setup`. For
+  `Playwright output is not compatible with this Playwright version...` set
+  `ai.agents.historian.framework: 'codeceptjs'`.
+
+**2 · Read the logs.** Everything is on disk under `output/` — start with
+`output/explorbot.log` (always-on). Then the relevant artifact: `output/reports/<mode>-*.md`
+(defects clustered), `output/research/<hash>.*` (what Researcher saw — for wrong-element /
+poor-plan issues), `output/states/rerun_<ts>/trace.md` + `*_screenshot.png` (rerun
+regressions). Re-run the failing command with `-v/--verbose` (or `DEBUG=explorbot:*`, or a
+namespace like `DEBUG=explorbot:tester,explorbot:navigator`) for more detail. Hanging? Check
+the last `explorbot.log` timestamp and `explorbot browser status`.
+
+**3 · Detailed debugging via Langfuse.** Prompt-level and agent-flow inspection (what each
+agent saw and decided) requires **Langfuse installed and configured** (`LANGFUSE_PUBLIC_KEY`
+/ `LANGFUSE_SECRET_KEY` in `.env`, or `ai.langfuse`). Then open the failed `tester.loop`
+trace, export it, and analyze it with the `explorbot-debug` Claude skill. Without Langfuse
+configured this depth of debugging is not available — recommend enabling it. See
+`docs/observability.md`.
+
+## Where to read more (docs/)
+
+In the installed package / repo `docs/`: `commands.md` · `configuration.md` (config+rules) ·
+`knowledge.md` · `planner.md` · `reporting.md` · `rerun.md` · `observability.md` (Langfuse) ·
+`providers.md` (AI providers) · `agents.md` · `page-interaction.md` · `prerequisites.md` ·
+`api-testing.md` · `automated-tests.md` · `scripting.md` (programmatic API) · `hooks.md`.

--- a/skills/explorbot-fundamentals/SKILL.md
+++ b/skills/explorbot-fundamentals/SKILL.md
@@ -1,164 +1,91 @@
 ---
 name: explorbot-fundamentals
-description: Core operating reference for Explorbot — the autonomous AI web-testing CLI. Use this skill whenever the user runs or debugs Explorbot via the command line: choosing freesail/explore/test, any `explorbot` CLI command or flag, config sections, knowledge/rules/experience, the output/ artifacts, reporting, secure credentials, providers, or troubleshooting a failing run. Guide-only — present the exact commands/paths/config; the user runs them. For first-time install/config use `explorbot-setup`.
+description: Use whenever the user runs, configures, or debugs Explorbot from the command line — choosing freesail/explore/test/plan/research, asking what a flag does, asking where an artifact lives, or troubleshooting a failed run. Guide-only — you present the commands/paths and the user runs them.
 license: MIT
 metadata:
   author: Testomat.io
-  version: 0.0.1
+  version: 0.1.0
 ---
 
-# EXPLORBOT-FUNDAMENTALS: What I do
+# Explorbot Fundamentals
 
-Explorbot explores a web app like a curious human — clicking, filling forms, finding bugs,
-learning — with no test scripts. It drives its own browser via CodeceptJS → Playwright (no
-MCP). Workflow: **research → plan → test → repeat**. It learns from experience and from the
-knowledge you give it.
+Explorbot is an autonomous AI web-testing CLI. It drives its own browser (CodeceptJS → Playwright) and works in cycles of **research → plan → test**.
 
-This skill is the operating reference: how to run and **debug** Explorbot from the command
-line, what each config/dir/output does, and where to read deeper docs. **Guide-only** —
-present commands and config; the user runs them. Do not edit files or run commands unless
-explicitly asked.
+This skill is intentionally short. **The installed CLI and the installed package's `docs/` tree are the source of truth — do not paraphrase them from memory.** Discover commands and read docs at the moment of use.
 
-## Execution mode: CLI only
+## Where the docs actually live
 
-**A coding agent can run Explorbot only through its non-interactive CLI commands** (e.g.
-`explorbot explore`, `explorbot test`, `explorbot plan`, `explorbot research`). These run
-headless and exit.
+Docs ship inside the npm package. After `npm i explorbot`, they're at:
 
-**`explorbot start` launches the interactive terminal UI (TUI). An agent cannot drive a
-TUI — never attempt to launch or operate it.** TUI slash commands (`/explore`, `/plan`,
-`/test`, `I.click(...)`, …) are for a human at the keyboard. If the user wants interactive
-mode, tell them to run `explorbot start [path]` themselves; everything an agent does for them
-uses the CLI equivalents below.
+```
+<project root>/node_modules/explorbot/docs/
+```
 
-Before anything: check `explorbot.config.{js,mjs,ts}` exists (also `config/`, `src/config/`).
-If none exists and the user wants to set up, defer to the **`explorbot-setup`** skill.
+That's the *only* place to read them from in a typical user project. Do **not** look in the skill's own folder, do **not** look in a project-level `docs/` (that belongs to the user's app), do **not** fetch from the web. If `node_modules/explorbot/docs/` doesn't exist, Explorbot isn't installed → route the user to **`explorbot-setup`**.
 
-## Main testing flows — widest to narrowest
+(For an Explorbot contributor working in the explorbot repo itself, docs are at `<repo root>/docs/`. Detect this by checking for `package.json` with `"name": "explorbot"` at the project root. Everyone else: `node_modules/explorbot/docs/`.)
 
-| Flow | Command | Scope | Notes |
-| --- | --- | --- | --- |
-| **freesail** | `explorbot freesail <path> --max-tests N` | Whole app, page by page, continuously | `--max-tests` required (it never stops on its own). `--deep` depth-first, `--shallow` breadth-first, `--scope /admin` to fence it |
-| **explore** | `explorbot explore /page --max-tests N` | One area + its subpages: research → plan → test → exit | `--max-tests` required. `--focus <feature>`, `--dry-run`, `--configure` to reuse/mix plans |
-| **test** | `explorbot test plan.md 1` | A single scenario from a plan | Narrowest. Author the plan with the `explorbot-plan` skill |
+## Rule 1 — Discover commands via the CLI
 
-Pick the widest flow the user actually wants: freesail for unattended coverage, explore for a
-section, test for one scenario. Always set `--max-tests` for freesail and explore.
+Always run the CLI's own help before answering a "how do I…" or "what flag…" question:
 
-`--configure` spec (semicolon pairs):
-`new:0%-100%;from:<plan>;style:normal,psycho,curious;priority:critical,high;pick_by:priority|random|index;subpages:none|same|new|both`.
-`explorbot test` index syntax: `1`, `1-5`, `1,3,7`, `*`/`all`, `"pattern"`.
+```bash
+npx explorbot --help                  # list every command
+npx explorbot <command> --help        # flags and options for one command
+```
 
-## Other CLI commands
+These outputs match the installed version. Any hardcoded list (in skills, blog posts, or your own memory) can be stale.
 
-| Command | Purpose |
-| --- | --- |
-| `explorbot plan <path> [feature]` | Generate a test plan (AI explores the live page) |
-| `explorbot plan:load <file> [i]` | Load a plan and list its tests (no run) |
-| `explorbot research <url>` | Analyze a page, print the UI map |
-| `explorbot drill <url>` | Drill components to learn interactions |
-| `explorbot context <url>` | Print page snapshot (HTML/ARIA/data) |
-| `explorbot learn [url] [desc]` | Add knowledge |
-| `explorbot knows [url]` | List/show knowledge |
-| `explorbot experience [filter] [i]` | Inspect learned experience |
-| `explorbot rerun <file> [i]` | Re-run generated tests with AI healing |
-| `explorbot runs [file]` | List generated tests / dry-run a file |
-| `explorbot extract-rules <agent>` | Scaffold editable agent rules / planner styles |
-| `explorbot browser start\|stop\|status` | Manage a persistent browser server |
+## Rule 2 — Read docs on demand, do not summarize ahead
 
-Common flags (all CLI): `-v, --verbose` / `--debug`, `-c, --config <path>`,
-`-p, --path <dir>`, `-s, --show` / `--headless`, `--incognito` (no experience),
-`--session [file]` (persist cookies/localStorage; default `output/session.json`).
+Pick the file that matches the topic *when the question comes up* — do not pre-load summaries. All paths below are relative to `node_modules/explorbot/docs/` (or the repo's `docs/` for contributors).
 
-## Credentials & secrets — never hardcode
+| Topic the user is asking about | Open |
+|---|---|
+| Is this app even suitable for explorbot? | `prerequisites.md` |
+| Full list of CLI + TUI commands and flags | `commands.md` |
+| Config file shape, `dirs:`, rules wiring | `configuration.md` |
+| AI providers (OpenRouter / OpenAI / Anthropic / Groq / Cerebras / Azure) | `providers.md` |
+| Knowledge files (URL patterns, frontmatter, interpolation) | `knowledge.md` |
+| Planner, planning styles, plan markdown format | `planner.md`, `test-plans.md` |
+| Researcher (page analysis) | `researcher.md` |
+| Page interaction model (locators, ARIA, iframes) | `page-interaction.md` |
+| Re-running generated tests with healing | `rerun.md` |
+| Generated test code (Playwright / CodeceptJS) | `automated-tests.md` |
+| Hooks | `hooks.md` |
+| Reporting (HTML/MD/Testomat.io) | `reporting.md` |
+| Tracing / Langfuse / observability | `observability.md` |
+| Library / programmatic use | `scripting.md`, `npm-package.md` |
+| API testing | `api-testing.md` |
+| Doc collector | `doc-collector.md` |
 
-All secrets load from the environment (`.env` or the shell), never literals in config or
-knowledge:
+If the topic isn't in this table, `ls node_modules/explorbot/docs/` and pick the matching file by name. Cite the file in your reply so the user can verify (e.g. "from `node_modules/explorbot/docs/knowledge.md`").
 
-| Secret | How |
-| --- | --- |
-| AI provider API key | `.env` (`OPENROUTER_API_KEY` / `OPENAI_API_KEY` / `ANTHROPIC_API_KEY` / `GROQ_API_KEY` / `CEREBRAS_API_KEY`); referenced as `process.env.X` in `explorbot.config.js` |
-| App / user login | Knowledge file body using `${env.USER}` / `${env.PASSWORD}`; real values in `.env`. Or `--session` to log in once and reuse cookies |
-| Testomat.io | `TESTOMATIO=<key>` env (plus `TESTOMATIO_TITLE/_ENV/_SHARED_RUN/_RUNGROUP_TITLE`) |
-| Langfuse | `.env` `LANGFUSE_PUBLIC_KEY` / `LANGFUSE_SECRET_KEY` (`LANGFUSE_BASE_URL` if self-hosted) |
+## Rule 3 — CLI only; never drive the TUI
 
-Confirm `.env` is git-ignored. In knowledge/config interpolate `${env.X}` / `${config.a.b}`;
-do not paste raw credentials.
+An agent can run only the non-interactive CLI (`explorbot explore`, `explorbot test`, `explorbot plan`, `explorbot research`, `explorbot navigate`, etc.). These run headless and exit.
 
-## Teaching Explorbot — knowledge, rules, experience
+**`explorbot start` launches an interactive terminal UI (TUI). An agent cannot operate a TUI — never try to launch or drive it.** If the user wants interactive mode, tell them to run `explorbot start [path]` themselves.
 
-| Dir | Who writes | What |
-| --- | --- | --- |
-| `./knowledge/` | You | Credentials, form rules, nav quirks. MD + YAML frontmatter: `url:` (pattern: `/exact`, `/path/*`, `*`, `^regex$`, `~contains`), `wait:`, `waitForElement:`, `code:` (CodeceptJS, `await tryTo/retryTo/within`), `statePush:`. Interpolate `${env.X}`, `${config.a.b}`. Add via `explorbot learn`. See `docs/knowledge.md` |
-| `./rules/<agent>/` | You | Per-agent instructions; `rules/planner/styles/*.md` planning styles. Wire via `ai.agents.<a>.rules: ['name', {'/path/*':'name'}]`. Scaffold: `explorbot extract-rules <agent>`. See `docs/configuration.md` |
-| `./experience/` | Explorbot | Memory layer - Auto-saved working locators/flows (FLOW/ACTION blocks + `related:` URLs). Inspect via `explorbot experience` |
+## Order of operations for every question
 
-Planning styles cycle `normal → psycho → curious` (outcome strength: data-change >
-state-change > UI-only). Reorder via `ai.agents.planner.styles`; add custom styles under
-`rules/planner/styles/`. See `docs/planner.md`.
+1. Verify `node_modules/explorbot/` exists. If not → route to **`explorbot-setup`**.
+2. Identify whether the user is asking about a **command/flag** (→ run `npx explorbot … --help`) or a **concept/config/feature** (→ open the matching file in `node_modules/explorbot/docs/`).
+3. Read the relevant source.
+4. Answer using what you just read, and cite it (`node_modules/explorbot/docs/knowledge.md`, `npx explorbot explore --help`).
 
-## output/ — what you get
+## Related skills
 
-| Path | Contents |
-| --- | --- |
-| `output/explorbot.log` | **Always-on activity log — start debugging here** |
-| `output/plans/*.md` | Generated test plans |
-| `output/tests/*.spec.ts` \| `*.js` | Runnable Playwright / CodeceptJS tests (commit to CI) |
-| `output/reports/<mode>-<session>.html` | HTML report (always created) |
-| `output/reports/<mode>-<session>.md` | Analyst session report (defects clustered by root cause) |
-| `output/reports/<mode>-<session>-tests.md` | Per-test markdown (when `reporter.markdown`) |
-| `output/research/<hash>.{html,aria.yaml,png}` | What Researcher saw |
-| `output/states/`, `states/rerun_<ts>/` | Per-step snapshots; rerun `trace.md` + aria/html/png/console |
-| `output/screencasts/*.webm` | Per-scenario video (when `historian.screencast`) |
-| `output/requests/` | API request/response logs |
-| `output/session.json` | Saved cookies/localStorage for `--session` |
+- [[explorbot-setup]] — install + config + verify reachability of one page (curl → navigate → credentials). Use this when `node_modules/explorbot/` is missing.
+- [[explorbot-plan]] — write a test plan markdown by hand without exploring a live page.
+- [[explorbot-debug]] — diagnose a failed session from `output/explorbot.log` + Langfuse traces.
+- [[explorbot-fix-session]] — once a session is diagnosed, propose a single minimal fix.
 
-Dirs relocatable via `dirs: { knowledge, experience, output }`.
+## Anti-patterns
 
-## Reporting & generated code
-
-- HTML report and the Analyst markdown are written every run under `output/reports/`.
-- **Recommended:** `reporter: { enabled: true, html: true, markdown: true }` → adds per-test
-  `…-tests.md`.
-- Runnable code: `ai.agents.historian.framework: 'playwright' | 'codeceptjs'` →
-  `output/tests/`. **Recommended:** `ai.agents.historian.screencast: true` (or
-  `{ size, quality }`) → `.webm` per scenario.
-- Testomat.io cloud via `TESTOMATIO` env or `reporter.enabled`; group with
-  `reporter.runGroup`. See `docs/reporting.md`. Rerun/healing tuning:
-  `ai.agents.rerunner.{healLimit,healMaxIterations,recipes}`, `docs/rerun.md`.
-- API testing: `api: { baseEndpoint, spec, headers, bootstrap, teardown }`;
-  `explorbot api plan|test|explore`. See `docs/api-testing.md`.
-
-## Troubleshooting — work the ladder in order
-
-**1 · Check the basics first.**
-- Playwright browsers installed (`npx playwright install`).
-- Target site reachable from this machine (try the URL in a normal browser).
-- AI reachable: provider key set in `.env`, model resolves. The error
-  `AI model is not configured. Set ai.model in your config file.` means key/model missing;
-  `Missing required configuration: web.url or playwright.url` means no base URL;
-  `No configuration file found...` → run `explorbot-setup`. For
-  `Playwright output is not compatible with this Playwright version...` set
-  `ai.agents.historian.framework: 'codeceptjs'`.
-
-**2 · Read the logs.** Everything is on disk under `output/` — start with
-`output/explorbot.log` (always-on). Then the relevant artifact: `output/reports/<mode>-*.md`
-(defects clustered), `output/research/<hash>.*` (what Researcher saw — for wrong-element /
-poor-plan issues), `output/states/rerun_<ts>/trace.md` + `*_screenshot.png` (rerun
-regressions). Re-run the failing command with `-v/--verbose` (or `DEBUG=explorbot:*`, or a
-namespace like `DEBUG=explorbot:tester,explorbot:navigator`) for more detail. Hanging? Check
-the last `explorbot.log` timestamp and `explorbot browser status`.
-
-**3 · Detailed debugging via Langfuse.** Prompt-level and agent-flow inspection (what each
-agent saw and decided) requires **Langfuse installed and configured** (`LANGFUSE_PUBLIC_KEY`
-/ `LANGFUSE_SECRET_KEY` in `.env`, or `ai.langfuse`). Then open the failed `tester.loop`
-trace, export it, and analyze it with the `explorbot-debug` Claude skill. Without Langfuse
-configured this depth of debugging is not available — recommend enabling it. See
-`docs/observability.md`.
-
-## Where to read more (docs/)
-
-In the installed package / repo `docs/`: `commands.md` · `configuration.md` (config+rules) ·
-`knowledge.md` · `planner.md` · `reporting.md` · `rerun.md` · `observability.md` (Langfuse) ·
-`providers.md` (AI providers) · `agents.md` · `page-interaction.md` · `prerequisites.md` ·
-`api-testing.md` · `automated-tests.md` · `scripting.md` (programmatic API) · `hooks.md`.
+- ❌ Listing commands or flags from memory → run `npx explorbot --help`.
+- ❌ Pasting big config snippets without opening `node_modules/explorbot/docs/configuration.md` first.
+- ❌ Looking for `docs/` in the skill's folder, in the user's project root, or on the web — they live in `node_modules/explorbot/docs/`.
+- ❌ Inventing a command that "should exist" — if `--help` doesn't show it, it doesn't exist.
+- ❌ Attempting to launch or "type into" `explorbot start` — you cannot drive the TUI.
+- ❌ Telling the user to use explorbot for a landing page / blog / CMS — `node_modules/explorbot/docs/prerequisites.md` says it's for CRUD-heavy apps.

--- a/skills/explorbot-plan/SKILL.md
+++ b/skills/explorbot-plan/SKILL.md
@@ -1,0 +1,97 @@
+---
+name: explorbot-plan
+description: Author an Explorbot test plan in markdown so `explorbot test` can run it. Use this skill whenever the user wants to create, write, or hand-author an Explorbot plan/test plan from a feature description, requirements, ticket, or docs — without exploring a live page. Produces a correctly formatted plan `.md` (suite, Prerequisite URL, prioritized scenarios with Steps and verifiable Expected outcomes) that Explorbot's Tester executes.
+license: MIT
+metadata:
+  author: Testomat.io
+  version: 0.0.1
+---
+
+# EXPLORBOT-PLAN SKILL: What I do
+
+Write an Explorbot **test plan** by hand in Explorbot's exact markdown format, from a feature
+description / requirements / docs and a starting URL. No browser or live exploration needed —
+this skill is the format contract.
+
+**Explorbot does not need to be installed to use this skill** — authoring a plan is just
+writing a markdown file. Installation is only required later to *run* the plan (via the
+`explorbot-fundamentals` skill: `explorbot test <planfile>`).
+
+## Inputs to gather
+
+- The feature / requirements / user story (ask for docs or a description).
+- A suite title (the feature under test).
+- The **start URL**: a path relative to the app host in `explorbot.config.js` `web.url`
+  (e.g. `/login`), or a full absolute URL. This is mandatory.
+- Optional per-test start URLs when a scenario begins on a different page.
+- Priority for each scenario: `critical`, `important`, `high`, `normal`, `low`.
+
+## Format
+
+```markdown
+<!-- suite -->
+# User Authentication
+
+### Prerequisite
+
+* URL: /login
+
+<!-- test
+priority: critical
+-->
+# User signs in with valid credentials
+
+## Requirements
+/login
+
+## Steps
+* Enter a registered email in the email field
+* Enter the matching password
+* Submit the sign-in form
+
+## Expected
+* The user lands on the authenticated dashboard
+* The signed-in account is shown in the header
+
+<!-- test
+priority: high
+-->
+# Sign-in is rejected for an unknown account
+
+## Requirements
+/login
+
+## Steps
+* Enter an unregistered email and any password
+* Submit the sign-in form
+
+## Expected
+* An invalid-credentials error is shown
+* The user stays on the sign-in page
+```
+
+## Rules
+
+- `<!-- suite -->` then the **next line** is `# Suite Title`. One suite per file is normal;
+  add more by repeating `<!-- suite -->`.
+- `### Prerequisite` — its **first list item** must be `* URL: <path>`. This documents the
+  suite-wide start page for readers and the TUI. A relative path resolves against `web.url` /
+  `playwright.url`; absolute URLs work too.
+- Each test: a `<!-- test` … `priority: <level>` … `-->` block, then `# Scenario` (h1).
+  Missing priority defaults to `normal`.
+- **Give every test its own `## Requirements` line with the start URL** (same value as the
+  Prerequisite, unless the scenario starts elsewhere). Execution reads the per-test
+  `## Requirements` URL; a test with no `## Requirements` may have no start URL and fail to
+  run. The canonical generated plans repeat the URL in every test for this reason.
+- `## Steps` and `## Expected` use `* ` bullets; wrap a long bullet by indenting continuation
+  lines two spaces.
+- Steps are **guidance** — the Tester adapts them; keep each step atomic and free of brittle
+  selectors. Every `## Expected` bullet must be **independently verifiable** (a data change,
+  state change, or UI change with a real side effect), not a restated step.
+- Scenario titles describe a **business outcome**, not a click path.
+
+## Output
+
+Save to `output/plans/<sanitized-start-path>[_<feature>].md` (e.g. `/login` + "auth" →
+`output/plans/login_auth.md`). Then tell the user to run it with the `explorbot-fundamentals`
+skill: `explorbot test output/plans/<file>.md`.

--- a/skills/explorbot-setup/SKILL.md
+++ b/skills/explorbot-setup/SKILL.md
@@ -1,0 +1,95 @@
+---
+name: explorbot-setup
+description: Install and configure Explorbot for the first time. Use this skill ONLY when there is no `explorbot.config.{js,mjs,ts}` in the project and the user wants to set Explorbot up (install it, pick an AI provider, create the config, and teach it initial knowledge such as login credentials). If a config already exists, use `explorbot-fundamentals` instead. Guide-only — present the exact commands/snippets; the user runs them.
+license: MIT
+metadata:
+  author: Testomat.io
+  version: 0.0.1
+---
+
+# EXPLORBOT-SETUP SKILL: What I do
+
+First-time install and configuration of Explorbot (the autonomous AI web-testing CLI).
+**Guide-only**: present the commands and config; the user runs them. Do not run installs or
+edit files unless the user explicitly asks.
+
+**Precondition:** only proceed if there is no `explorbot.config.js` / `.mjs` / `.ts` (also
+checked under `config/` and `src/config/`). If one exists, stop and point the user to
+`explorbot-fundamentals`.
+
+## 1. Install
+
+```bash
+npm i explorbot --save
+npx playwright install
+```
+
+Requirements: Node ≥ 24 or Bun; an AI provider API key; a modern terminal (iTerm2, WARP,
+Kitty, Ghostty, Windows Terminal — WSL on Windows). Not for landing/blog/static sites — see
+`docs/prerequisites.md` (isolated/staging env, non-critical data, restricted permissions).
+
+## 2. Initialize config
+
+```bash
+npx explorbot init
+```
+
+Generates `explorbot.config.js` + `.env`. Options: `-c, --config-path <path>`
+(default `./explorbot.config.js`), `-f, --force`, `-p, --path <dir>`.
+
+## 3. Set app URL and AI provider
+
+Edit `explorbot.config.js`: set `web.url` to the app host (host only, no path), and choose a
+provider. OpenRouter is recommended (one key, many models); any Vercel AI SDK provider works
+(`docs/providers.md` for Groq/OpenAI/Anthropic/Cerebras/Google/Azure imports).
+
+```javascript
+import { createOpenRouter } from '@openrouter/ai-sdk-provider';
+
+const openrouter = createOpenRouter({ apiKey: process.env.OPENROUTER_API_KEY });
+
+export default {
+  web: { url: 'https://your-app.com' },
+  ai: {
+    model: openrouter('openai/gpt-oss-20b'),                          // fast/cheap: HTML+ARIA (Tester/Navigator/Researcher)
+    visionModel: openrouter('meta-llama/llama-4-scout-17b-16e-instruct'), // screenshots
+    agenticModel: openrouter('minimax/minimax-m2.5:nitro'),           // smart decisions (Captain/Pilot) — cheap to upgrade
+  },
+};
+```
+
+Put the API key in `.env` (`OPENROUTER_API_KEY=`, or `OPENAI_API_KEY` / `ANTHROPIC_API_KEY` /
+`GROQ_API_KEY` / `CEREBRAS_API_KEY`). The three models are distinct and all needed; per-agent
+overrides via `ai.agents.<name>.model`.
+
+## 4. Teach initial knowledge (do this — don't skip)
+
+Most apps need login. Ask the user for: the app URL/path to start from, login credentials (or
+that auth is not required), and any must-know quirks (required form fields, loading waits,
+test data/roles). Then record it:
+
+```bash
+npx explorbot learn                                    # interactive
+npx explorbot learn "/login" "Use credentials: admin@example.com / secret123"
+npx explorbot learn "*" "General rule that applies to every page"
+```
+
+This writes markdown files to `./knowledge/` (frontmatter `url:` pattern + body). Prefer
+referencing secrets as `${env.USER}` / `${env.PASSWORD}` and putting real values in `.env`.
+URL patterns: `/login` exact, `/admin/*` glob, `*` all pages, `^/users/\d+` regex,
+`~dashboard` contains. See `docs/knowledge.md`.
+
+Tip: `--session` persists cookies/localStorage so login happens once:
+`npx explorbot start /login --session` then later `npx explorbot start /app --session`.
+
+## 5. Verify
+
+Have the **user** launch the interactive TUI themselves (an agent cannot drive a TUI):
+
+```bash
+npx explorbot start /admin/users --show
+```
+
+Start from a small CRUD area so Explorbot grasps context fast. For agent-driven, headless
+runs and all debugging, hand off to `explorbot-fundamentals` (CLI: `explorbot explore` /
+`freesail` / `test`).

--- a/skills/explorbot-setup/SKILL.md
+++ b/skills/explorbot-setup/SKILL.md
@@ -1,95 +1,347 @@
 ---
 name: explorbot-setup
-description: Install and configure Explorbot for the first time. Use this skill ONLY when there is no `explorbot.config.{js,mjs,ts}` in the project and the user wants to set Explorbot up (install it, pick an AI provider, create the config, and teach it initial knowledge such as login credentials). If a config already exists, use `explorbot-fundamentals` instead. Guide-only — present the exact commands/snippets; the user runs them.
+description: Use to install and configure Explorbot from scratch and prove it can reach the user's app. The skill ends when `explorbot navigate` succeeds on the user's target page; from there hand off to `explorbot-fundamentals`. Performs the work itself — installs packages, edits config, runs the verification ladder — only stopping to ask the user for the things only they know (provider choice, app URL, credentials).
 license: MIT
 metadata:
   author: Testomat.io
-  version: 0.0.1
+  version: 0.3.0
 ---
 
-# EXPLORBOT-SETUP SKILL: What I do
+# Explorbot Setup
 
-First-time install and configuration of Explorbot (the autonomous AI web-testing CLI).
-**Guide-only**: present the commands and config; the user runs them. Do not run installs or
-edit files unless the user explicitly asks.
+Install Explorbot, write a working config, give it the bare minimum knowledge to reach the user's app, and prove the install by getting `explorbot navigate <page>` to exit `0`.
 
-**Precondition:** only proceed if there is no `explorbot.config.js` / `.mjs` / `.ts` (also
-checked under `config/` and `src/config/`). If one exists, stop and point the user to
-`explorbot-fundamentals`.
+**Scope ends at a successful `navigate`.** Running `explore`, `plan`, `test`, `freesail`, etc. is not part of setup — once navigate works, hand the user off to **`explorbot-fundamentals`**.
 
-## 1. Install
+**Do the work — don't narrate it.** Run installs, run `explorbot init`, edit `explorbot.config.js`, run `curl`, run `explorbot navigate`, run `explorbot learn` yourself. The user is only asked for the things only they know:
+
+1. AI provider + API key (OpenRouter / OpenAI / Anthropic / Groq / Cerebras / Azure / Google)
+2. App URL (the value of `web.url`)
+3. The page to verify against
+4. Login credentials (only if `navigate` fails on an auth wall)
+
+Don't pre-collect those four upfront — ask each one at the moment it's actually needed, and only ask for credentials at all if the ladder shows they're needed.
+
+## Communication style — friendly and explanatory
+
+This is the user's **first contact with Explorbot**. Most of them have never seen it before. Don't be terse, don't be transactional, and don't dump options without context.
+
+**Before every ask and before every install step, write 2–4 sentences that cover:**
+
+- **What** is about to happen ("I'm going to install Playwright's browsers — about 250MB, takes a couple of minutes.")
+- **Why** it's needed ("Explorbot drives a real browser to click around your app like a user would — Playwright is the engine, the browsers are what it drives.")
+- **What the user gets** from it ("Once this is done, Explorbot can navigate any URL on your app and try things autonomously.")
+
+When asking a question, **explain the choice itself** — what each option means, what the trade-off is, why you recommend one. Don't make the user guess what a label means.
+
+When showing a long command or a config snippet you're about to apply, say in one sentence what it does first.
+
+After every step, give a short progress note ("Installed. Next: …") so the user knows where they are in a multi-step process. Use light formatting (a single emoji or `**Step N/6**` markers) only when it actually helps — never decorate for the sake of it.
+
+Keep the tone warm and confident, not apologetic. Errors get a friendly explanation of what likely went wrong and what you'll try next, not a wall of stack trace.
+
+## Precondition check
+
+If `explorbot.config.{js,mjs,ts}` already exists (also check `config/`, `src/config/`) and the user is already running Explorbot, **stop and route them to `explorbot-fundamentals`** — this skill is for first-time install.
+
+## 1 — Install
+
+Verify Node ≥ 24 (or Bun) first; if neither is available, stop and tell the user — don't try to install a runtime.
+
+**Make sure `package.json` exists and is ESM.** Explorbot's generated config uses `import …` statements, which need `"type": "module"`. The default `npm init -y` produces CommonJS — that breaks the config. If there's no `package.json` in the project, create one as ESM:
+
+```bash
+npm init -y
+npm pkg set type=module
+```
+
+If `package.json` already exists but `"type"` is missing or set to `"commonjs"`, ask the user before changing it (could affect their existing code). If they consent, run `npm pkg set type=module`. If they don't, you'll need to write the explorbot config as `.mjs` instead and pass `--config-path explorbot.config.mjs` to every command.
+
+Then install Explorbot and the browsers it drives:
 
 ```bash
 npm i explorbot --save
 npx playwright install
 ```
 
-Requirements: Node ≥ 24 or Bun; an AI provider API key; a modern terminal (iTerm2, WARP,
-Kitty, Ghostty, Windows Terminal — WSL on Windows). Not for landing/blog/static sites — see
-`docs/prerequisites.md` (isolated/staging env, non-critical data, restricted permissions).
+**Explain to the user before running these**, in this spirit (paraphrase, don't paste verbatim):
 
-## 2. Initialize config
+> "Two installs coming up. First, `npm i explorbot --save` pulls Explorbot into your project — the CLI you'll use to run everything later. Then `npx playwright install` downloads the Chromium / Firefox / WebKit browser binaries (~250MB, takes a minute or two). Explorbot drives a real browser to interact with your app the way a person would — clicks, forms, navigation — and Playwright is the engine that lets it do that. Without these browsers, Explorbot has nothing to drive."
+
+If the user's app is a landing page, blog, or CMS, **stop and warn them** before installing — Explorbot is built for CRUD-heavy apps (SaaS, admin panels, ecommerce, ERPs, internal tools) and performs poorly on static / content sites. Explain *why* (it learns by interacting with forms, tables, CRUD actions — there's nothing for it to do on a marketing page). Continue only if they confirm.
+
+## 2 — Initialize the config
+
+Run:
 
 ```bash
 npx explorbot init
 ```
 
-Generates `explorbot.config.js` + `.env`. Options: `-c, --config-path <path>`
-(default `./explorbot.config.js`), `-f, --force`, `-p, --path <dir>`.
+This creates `explorbot.config.js` and `.env`. For flag options (`--config-path`, `--force`, `--path`), check `npx explorbot init --help`.
 
-## 3. Set app URL and AI provider
+## 3 — Configure `web.url` and an AI provider
 
-Edit `explorbot.config.js`: set `web.url` to the app host (host only, no path), and choose a
-provider. OpenRouter is recommended (one key, many models); any Vercel AI SDK provider works
-(`docs/providers.md` for Groq/OpenAI/Anthropic/Cerebras/Google/Azure imports).
+**Read the generated `explorbot.config.js`** — `explorbot init` writes a working template with placeholders. Work from that file's current shape; don't paste a config from memory.
 
-```javascript
-import { createOpenRouter } from '@openrouter/ai-sdk-provider';
+Ask the user two things, then edit the file:
 
-const openrouter = createOpenRouter({ apiKey: process.env.OPENROUTER_API_KEY });
+1. **App URL** — `web.url` (host only, no path).
+2. **AI provider + API key** — which one (OpenRouter / OpenAI / Anthropic / Groq / Cerebras / Azure / Google) and the key value.
 
-export default {
-  web: { url: 'https://your-app.com' },
-  ai: {
-    model: openrouter('openai/gpt-oss-20b'),                          // fast/cheap: HTML+ARIA (Tester/Navigator/Researcher)
-    visionModel: openrouter('meta-llama/llama-4-scout-17b-16e-instruct'), // screenshots
-    agenticModel: openrouter('minimax/minimax-m2.5:nitro'),           // smart decisions (Captain/Pilot) — cheap to upgrade
-  },
-};
+### How to ask for the URL — explain, then ask (no guessing)
+
+The app under test is **the user's app** — could be a local dev server (`http://localhost:<port>`) or one of their hosted environments (staging / dev / production). **You cannot guess it.** Do not pre-fill URL options with "common defaults" and never with unrelated apps (`app.testomat.io`, `example.com`, anything from the skill's metadata).
+
+Before asking, **explain why you need it** in this spirit:
+
+> "Explorbot needs to know which web app to test. This is set as `web.url` in `explorbot.config.js` and becomes the base for every navigation — paths like `/login` or `/dashboard` will be resolved against it. It can be a local dev server (something running on `localhost`) or a hosted environment you own — staging or dev are usually safer than production, since Explorbot will click, fill, and submit forms autonomously and could create or change data."
+
+Then:
+
+1. **Look for evidence in the project first** — read `package.json` `scripts` for `dev` / `start` / `serve` lines, check `.env` / `.env.example` for `BASE_URL` / `APP_URL` / `NEXT_PUBLIC_*_URL` / `VITE_*_URL`, look at framework config (`next.config.*`, `vite.config.*`, `vue.config.*`) for a `port` setting. If you find a concrete URL or port, surface it as a *suggestion with its source* ("Found `PORT=4000` in `.env` — use `http://localhost:4000`?"). Never invent a URL without an actual source in the project.
+2. **Optionally probe** ports the project implies — if `package.json` runs `next dev`, Next's default is 3000; check whether `http://localhost:3000` actually responds via `curl`. Only suggest a port that something is currently listening on, and say so ("Something is listening on `localhost:3000` — is that your app?").
+3. **If no evidence** — ask in plain text: *"What's the URL of the app Explorbot should test? Local (e.g. `http://localhost:<port>`) or a hosted environment of yours (staging / dev / production — please avoid production if it'll create real data)?"* No multiple-choice list, no guesses.
+
+Confirm what they answer back to them before writing it into the config.
+
+### How to ask for the AI provider — explain first
+
+Most users have never connected an LLM to a test tool before. Before asking, **explain what's happening and why**, in this spirit:
+
+> "Explorbot is driven by an LLM — that's what looks at each page, decides what to click, fills forms intelligently, and judges whether a test passed. So Explorbot needs API access to a model, which means a token-based API key from a provider you have an account with. Costs are per-token (typically cents per exploration run), nothing fixed or monthly. The key stays local — written to `.env` in this project — and `.env` will be gitignored.
+>
+> Three providers I'd suggest, in order:
+> - **OpenRouter** — easiest to start with. One account, one key, access to almost every model (OpenAI, Anthropic, Meta, Mistral, etc.) so you can swap models without re-onboarding. Good if you don't have a strong preference.
+> - **OpenAI** — if you already have an OpenAI key, this is one less account.
+> - **Anthropic** — if you already use Claude, same reason.
+>
+> Anything else that Vercel's AI SDK supports also works (Groq, Cerebras, Azure OpenAI, Google Gemini, etc.) — tell me which one and I'll wire it."
+
+Then ask which one (and the API key value), and act on it:
+
+- The template `explorbot init` generated already imports a provider; if the user picks a different one, swap the import line + the three `model:` / `visionModel:` / `agenticModel:` lines accordingly.
+- The provider package follows the Vercel AI SDK convention: `@openrouter/ai-sdk-provider`, `@ai-sdk/openai`, `@ai-sdk/anthropic`, `@ai-sdk/groq`, `@ai-sdk/google`, `@ai-sdk/azure`, etc. `npm i` the matching one if it isn't already a dep — tell the user what you're installing and why.
+- Reference the key in the config as `process.env.<KEY_NAME>` (e.g. `process.env.OPENROUTER_API_KEY`) and confirm `.env` is in `.gitignore`. If it isn't, **explain why you want to add it** ("so your key doesn't end up in git history") and add it.
+
+### How to get the key into `.env` — offer three options, recommend the editor
+
+The key itself never has to pass through the chat. Present these three options and **recommend option 1**:
+
+1. **Edit `.env` yourself, then continue (recommended).** This is the most secure path — the key never goes through chat, never lands in transcripts or logs. Say to the user, in this spirit:
+
+   > "I'd recommend the safest way: open `.env` in your editor, add the line `OPENROUTER_API_KEY=…` (paste the value there), save, then just tell me 'continue' or 'ready' and I'll pick up the verification step. The key never has to pass through this chat that way."
+
+   When they confirm they've saved it, verify it's set before continuing:
+
+   ```bash
+   grep -q "^<KEY_NAME>=." .env && echo "key present" || echo "key missing"
+   ```
+
+   If "key missing", tell them and wait — don't proceed to step 5.
+
+2. **Paste the key here and I'll write it.** Less secure (the key passes through chat), but convenient. Only use this if the user explicitly prefers it. When they paste, write it to `.env` immediately and do not echo the value back in your reply.
+
+3. **Skip for now — I'll set it up later.** Legitimate, but be clear: setup will **stop at step 4**, no verification will run. They'll finish by editing `.env` themselves and then running `npx explorbot navigate <path> --session` manually. Recommend they come back through `explorbot-fundamentals` once the key is in place.
+
+Do not list these in a `1/2/3` multiple-choice prompt where #1 looks just as casual as the others — call option 1 out as the recommended one in your explanation, and frame option 2 as the less-secure alternative.
+
+(Once Explorbot is installed, the canonical reference for everything in this section is `node_modules/explorbot/docs/configuration.md` and `node_modules/explorbot/docs/providers.md`. The fundamentals skill uses these — setup shouldn't need them unless the generated template is unclear.)
+
+## 4 — Pick the verification page
+
+Before asking, **explain why**:
+
+> "Setup isn't done until I've proven Explorbot can actually open a page on your app — that catches network issues, wrong URL, auth walls, or a misconfigured browser before we waste a real exploration run. Pick any page on your app: the home page (`/`), a login page (`/login`), or a specific area you'll want to test later (e.g. `/admin/users`). I'll try a cheap reachability check first, then ask Explorbot to navigate there."
+
+Then ask: *"Which page should I use for the verification? You can paste a full URL or just a path like `/login`."*
+
+If they mention login is required up front, ask for credentials now (see step 5C for how — same flow). Otherwise wait; the ladder will surface it cleanly if it's needed.
+
+## 5 — Verify with the accessibility ladder
+
+Walk these rungs **in order**. Stop at the first failure, fix it, then resume. Do not skip ahead.
+
+```dot
+digraph accessibility_ladder {
+    rankdir=TB;
+    "A. curl page" [shape=box];
+    "A.5 curl -IL follow redirects" [shape=box];
+    "B. explorbot navigate --session" [shape=box];
+    "C. teach auth (knowledge → creds)" [shape=box];
+    "Setup done → handoff" [shape=doublecircle];
+    "host reachable?" [shape=diamond];
+    "page gated (3xx/401/403)?" [shape=diamond];
+    "final URL looks like login?" [shape=diamond];
+    "navigate exit 0?" [shape=diamond];
+    "auth wall after the fact?" [shape=diamond];
+
+    "A. curl page" -> "host reachable?";
+    "host reachable?" -> "fix env (VPN, DNS, web.url), retry A" [label="no"];
+    "host reachable?" -> "page gated (3xx/401/403)?" [label="yes"];
+    "page gated (3xx/401/403)?" -> "B. explorbot navigate --session" [label="no (200)"];
+    "page gated (3xx/401/403)?" -> "A.5 curl -IL follow redirects" [label="yes"];
+    "A.5 curl -IL follow redirects" -> "final URL looks like login?";
+    "final URL looks like login?" -> "C. teach auth (knowledge → creds)" [label="yes"];
+    "final URL looks like login?" -> "B. explorbot navigate --session" [label="no (plain redirect)"];
+    "C. teach auth (knowledge → creds)" -> "B. explorbot navigate --session" [label="knows → learn → ask → verify .env"];
+    "B. explorbot navigate --session" -> "navigate exit 0?";
+    "navigate exit 0?" -> "Setup done → handoff" [label="yes"];
+    "navigate exit 0?" -> "auth wall after the fact?" [label="no"];
+    "auth wall after the fact?" -> "C. teach auth (knowledge → creds)" [label="yes"];
+    "auth wall after the fact?" -> "read output/explorbot.log, fix knowledge, retry B" [label="no"];
+}
 ```
 
-Put the API key in `.env` (`OPENROUTER_API_KEY=`, or `OPENAI_API_KEY` / `ANTHROPIC_API_KEY` /
-`GROQ_API_KEY` / `CEREBRAS_API_KEY`). The three models are distinct and all needed; per-agent
-overrides via `ai.agents.<name>.model`.
+### A — `curl` the host
 
-## 4. Teach initial knowledge (do this — don't skip)
-
-Most apps need login. Ask the user for: the app URL/path to start from, login credentials (or
-that auth is not required), and any must-know quirks (required form fields, loading waits,
-test data/roles). Then record it:
+Run a cheap network check before involving Explorbot. Build the full URL from the `web.url` you just wrote into the config plus the verification path.
 
 ```bash
-npx explorbot learn                                    # interactive
-npx explorbot learn "/login" "Use credentials: admin@example.com / secret123"
-npx explorbot learn "*" "General rule that applies to every page"
+curl -sS -o /dev/null -w "HTTP %{http_code} in %{time_total}s\n" <full-url-to-target-page>
 ```
 
-This writes markdown files to `./knowledge/` (frontmatter `url:` pattern + body). Prefer
-referencing secrets as `${env.USER}` / `${env.PASSWORD}` and putting real values in `.env`.
-URL patterns: `/login` exact, `/admin/*` glob, `*` all pages, `^/users/\d+` regex,
-`~dashboard` contains. See `docs/knowledge.md`.
+Interpret the result yourself:
 
-Tip: `--session` persists cookies/localStorage so login happens once:
-`npx explorbot start /login --session` then later `npx explorbot start /app --session`.
+- `000` → DNS / VPN / wrong host / `web.url` wrong. Tell the user what's likely wrong (VPN, DNS, typo in URL), fix what you can, re-run A.
+- `200` → host is up and serving the page; continue to B.
+- `3xx` / `401` / `403` → host is up but the page is gated. **Run A.5 first.**
+- `5xx` → the app itself is broken. Stop and report to the user.
 
-## 5. Verify
+### A.5 — Auth probe (only when A returned 3xx / 401 / 403)
 
-Have the **user** launch the interactive TUI themselves (an agent cannot drive a TUI):
+Don't fire `explorbot navigate` blind into an auth wall — that wastes an AI run when you can already tell credentials will be needed. Follow the redirects with `curl` and see where the host actually sends an unauthenticated request:
 
 ```bash
-npx explorbot start /admin/users --show
+curl -sIL -o /dev/null -w "final=%{url_effective}\nhttp=%{http_code}\n" <full-url-to-target-page>
 ```
 
-Start from a small CRUD area so Explorbot grasps context fast. For agent-driven, headless
-runs and all debugging, hand off to `explorbot-fundamentals` (CLI: `explorbot explore` /
-`freesail` / `test`).
+Look at the final URL and decide:
+
+- The final URL path contains `login`, `sign_in`, `signin`, `auth`, `session/new`, `account/login`, `oauth`, `sso`, `idp`, or returns `401` / `403` after following redirects → **the app needs credentials.** Jump to step C *now* (before B), gather credentials, store them, and only then run B.
+- The final URL is just a different non-auth path (e.g. `/` → `/dashboard` because there's a working session, or `/old-url` → `/new-url`) → no auth needed, continue straight to B.
+- Ambiguous (e.g. lands on `/` with no login-like keywords)? Tell the user what you saw ("`/` redirected to `/welcome` — is that page open to anonymous users, or does it need a login?") and let them decide.
+
+Tell the user what you found before asking, in this spirit:
+
+> "Heads up — `curl` on `/` returned 302 and follows through to `https://beta.testomat.io/users/sign_in`. That's a login page, so Explorbot will hit the same wall when it tries to navigate. Let me grab credentials from you now so the verification run actually gets past it."
+
+Then go to C, then B.
+
+### B — `explorbot navigate`
+
+Run the AI Navigator against the target page. It handles redirects, login walls, and recoverable errors.
+
+```bash
+npx explorbot navigate <path> --session
+```
+
+`--session` captures cookies/localStorage into `output/session.json` so the next setup attempts reuse the auth. For other flags, check `npx explorbot navigate --help` on the spot.
+
+Interpret the exit code:
+
+- Exit `0` → **setup is done. Go to step 6.**
+- Exit `1` → read `output/explorbot.log` and figure out why. If it's a login redirect / 401 / 403, go to C. Otherwise the cause is not credentials (wrong URL, missing wait, app down): fix the knowledge or the config yourself if you can, and re-run B. If you can't tell, surface the log excerpt to the user and ask.
+
+### C — Teach Explorbot about auth (knowledge first, then credentials)
+
+Enter step C either because step A.5 detected a login redirect *or* because step B's navigate landed on auth. Do not invent credentials. Do not loop without asking.
+
+**The order matters.** Knowledge (the markdown file that tells Explorbot *how* to authenticate) is written first, using placeholder env-var references. Real credentials go into `.env` afterwards. If you ask for credentials first and only write knowledge later, you'll race the user — they'll fill `.env`, say "continue", and you'll run navigate against a config that still has no knowledge file. That's the exact bug to avoid.
+
+#### C.1 — Check what knowledge already exists
+
+Before writing anything, see what `knowledge/` already has for this URL — there might be auth knowledge from a prior attempt or from the user's own work, and you should not duplicate it.
+
+```bash
+npx explorbot knows <auth-page-path>     # e.g. npx explorbot knows /users/sign_in
+npx explorbot knows                       # if you need a quick overview of everything
+```
+
+If an entry already covers sign-in for this URL, **read it** (open the file under `knowledge/`), note which env vars it references, and skip C.2 — jump to C.3 and ask the user to populate those existing vars in `.env`.
+
+If nothing relevant is there, continue to C.2.
+
+#### C.2 — Write knowledge with env-var placeholders (no real secrets yet)
+
+Pick env var names you'll ask the user to populate next — `APP_USER` / `APP_PASSWORD` are sensible defaults; reuse what existing knowledge already uses if any. Then run `explorbot learn` with a **simple** body that names the credentials and references the env vars. Do not invent field selectors, CSS, or DOM hints — the Navigator figures those out on its own; over-specifying makes the knowledge brittle.
+
+```bash
+npx explorbot learn "<auth-page-path>" "Sign in with \${env.APP_USER} / \${env.APP_PASSWORD}."
+```
+
+Confirm with `npx explorbot knows <auth-page-path>` (or by reading the file under `knowledge/`) that the placeholders survived literally — no real values, no escaped backslashes that broke the substitution.
+
+Tell the user in plain language what you just did, in this spirit:
+
+> "I wrote `knowledge/<file>.md` so Explorbot knows it should sign in on `<auth-page-path>` using the env vars `APP_USER` / `APP_PASSWORD`. No real credentials are in that file — it just references those two variables. Now I need the actual values."
+
+#### C.3 — Ask for the actual credentials, recommend the editor
+
+Explain first what's happening and the safety implications:
+
+> "The knowledge file is in place but it references env vars that don't have values yet. Please add the two values to `.env` (which is gitignored, so they stay local). I'd recommend the safest path — open `.env` in your editor, add the two lines, save, and tell me 'continue'. The credentials never have to pass through this chat.
+>
+> A safety note: please use a **test account**, not a real admin / personal one — Explorbot will click and submit autonomously, so anything that account can do, it might do. If your app has a staging or dev environment, point at that."
+
+Offer the same three options you use for the API key in step 3 (edit `.env` yourself *recommended*; paste here *less secure*; skip *setup stops here*). Tell them exactly which lines to add:
+
+```
+APP_USER=…
+APP_PASSWORD=…
+```
+
+If you also need to know the **login URL**, the **role / workspace / tenant**, or anything else, ask for those too — but only if the Navigator can't reasonably infer them from the page.
+
+#### C.4 — Verify the env vars are set, then retry navigate
+
+When the user says "continue", verify before invoking navigate:
+
+```bash
+grep -E "^(APP_USER|APP_PASSWORD)=." .env >/dev/null && echo "creds set" || echo "creds missing"
+```
+
+If "creds missing", tell the user which line is empty and wait — don't proceed.
+
+If "creds set", retry step B (`npx explorbot navigate <path> --session`). If navigate now exits `0`, setup is done. If it still fails:
+
+- Read `output/explorbot.log` for the actual cause.
+- If it still looks like an auth issue, the knowledge body may need a small hint (e.g. the user lands on `/login` but `/users/sign_in` is the actual form, or the app has SSO / a second factor). Re-run `explorbot learn` with one short added sentence, not a rewrite. Then retry navigate.
+- If it's not auth (wrong URL, missing wait, server error), share the log excerpt with the user and decide together — don't loop blindly.
+
+## 6 — Handoff
+
+When `explorbot navigate <path> --session` exits `0`, setup is complete. Give the user a warm wrap-up, in this spirit:
+
+> "🎉 Setup is done — Explorbot just opened `<path>` on your app successfully. Here's where you stand:
+>
+> - `explorbot.config.js` is configured with your URL and AI provider.
+> - Your API key and any credentials are in `.env` (gitignored).
+> - `output/session.json` holds a working browser session, so future runs won't re-login.
+>
+> From here, you'd typically:
+> - Run **`npx explorbot research <path>`** to see what Explorbot understands about a page (cheap, no testing yet).
+> - Run **`npx explorbot explore <path> --max-tests 10`** for a real exploration cycle (research → plan → test).
+> - Or write a plan by hand and run it with **`npx explorbot test <plan.md>`**.
+>
+> The `explorbot-fundamentals` skill walks through all of that and is what you'll want for everything beyond setup. Want me to hand off there?"
+
+Do not run `explore`, `plan`, `test`, or `freesail` from this skill — that's fundamentals' job.
+
+## Anti-patterns
+
+- ❌ Printing the commands and waiting for the user to run them — this skill **does** the install and the ladder itself. Only the four user-only inputs (provider, app URL, page, credentials) are deferred to the user.
+- ❌ Asking for target page / subpages / feature focus / max-tests upfront — none of that is needed for setup; only ask which page to verify, at step 4.
+- ❌ Pasting config snippets or provider imports from memory — work from the template `explorbot init` just generated, or (only if unclear) `node_modules/explorbot/docs/providers.md`.
+- ❌ Referring to `docs/` ambiguously — once Explorbot is installed, docs live at `node_modules/explorbot/docs/`. Never look in the skill's own folder or in a project-relative `docs/`.
+- ❌ Hardcoding credentials in knowledge markdown or in `explorbot.config.js` — always write secrets into `.env`, reference via `${env.X}`.
+- ❌ Skipping `curl` — it's the cheapest way to catch a DNS / VPN / wrong-host issue and saves an Explorbot run.
+- ❌ Seeing a `3xx` / `401` / `403` from `curl` and running `explorbot navigate` anyway "to see what happens" — follow the redirect with `curl -sIL` (step A.5), and if it lands on a login / sign-in / auth / SSO URL, gather credentials *before* invoking navigate. Don't burn an AI run to discover what HTTP already told you.
+- ❌ Writing the credentials to `.env` first and the knowledge file later — that races the user. Write knowledge via `npx explorbot learn` (with env-var placeholders) *before* asking the user to populate `.env`, otherwise navigate runs against a config with no auth knowledge and fails for the second time.
+- ❌ Skipping `npx explorbot knows <path>` before writing knowledge — there may already be a sign-in entry from a prior attempt or from the user's own work. Read it first; don't duplicate it.
+- ❌ Padding the auth knowledge body with CSS selectors / field IDs / DOM hints — `Sign in with ${env.APP_USER} / ${env.APP_PASSWORD}.` is enough. The Navigator figures out the form; over-specifying makes knowledge brittle and breaks the moment the app changes a class name.
+- ❌ Running `explore`, `plan`, `test`, or `freesail` to "verify" — they're expensive and out of scope. `navigate` exit `0` is the verification.
+- ❌ Trying to drive `explorbot start` (the TUI) — agents cannot operate a TUI; if the user wants interactive mode, tell them to run it themselves.
+- ❌ Bootstrapping the project with `npm init -y` and leaving it CommonJS — explorbot's config uses `import …` and needs `"type": "module"` (or write the config as `.mjs`).
+- ❌ Pre-filling URL options with "common defaults" or anything from the skill metadata (e.g. `app.testomat.io`). The URL is the user's app — derive it from project evidence (`package.json` scripts, `.env`, framework config, listening ports) or ask in plain text. Never guess.
+- ❌ Asking the user to paste the API key into chat as the default path, or framing "paste here" and "edit `.env` yourself" as equally-weighted multiple-choice options. The editor route is the **recommended** one (the key never enters chat / transcripts / logs); pasting is the less-secure alternative; skipping stops setup. Make the recommendation explicit.


### PR DESCRIPTION
## What

Adds a new **`explorbot`** Claude Code plugin for [Explorbot](https://github.com/testomatio/explorbot), the autonomous AI web-testing CLI. Three guide-only skills:

| Skill | Purpose |
|---|---|
| `explorbot-setup` | First-time install, AI provider/config setup, initial knowledge (login credentials). Triggers only when no `explorbot.config` exists. |
| `explorbot-fundamentals` | Operating + debug reference: CLI-only execution, the freesail→explore→test flows, config, knowledge/rules/experience, `output/` artifacts, reporting, secure credentials, troubleshooting ladder, docs index. |
| `explorbot-plan` | Author an Explorbot test plan in markdown (exact format contract) so `explorbot test` can run it. No Explorbot install needed to author. |

## Structure

Canonical skills live in `skills/explorbot-*/`, symlinked into `plugins/explorbot/skills/` via `../../../skills/*` — identical convention to `test-automation` / `test-management`. Registered in `.claude-plugin/marketplace.json` and documented in `README.md`.

## Notes

- All skills are **guide-only** (present commands/config; the user runs them).
- The plan format was verified end-to-end against Explorbot's own `parsePlanFromMarkdown`; `explorbot-plan` encodes the per-test `## Requirements` URL rule the parser requires.
- No code, only markdown skills + JSON manifests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)