### PR TITLE
More fixes for generate-cases skill

### DIFF
--- a/skills/generate-cases/SKILL.md
+++ b/skills/generate-cases/SKILL.md
@@ -49,7 +49,7 @@ Trigger this skill when the user:
 
 - Fill input fields with suggestions when asking user to provide input.
 
-- Questions and outputs should be structured, formated to be easy to read and understand.
+- **Keep terminal/chat output to the user short, concise, well-structured and formatted.** Avoid long paragraphs, walls of text, redundant restatements, or verbose status updates. Prefer bullet lists, short headings, tables and emoji markers over prose. Show only what the user needs to make the next decision — details on request.
 
 ## Workflow (IMPORTANT: how AI tool (Claude, Cursor etc) should work with user)
 

--- a/skills/generate-cases/SKILL.md
+++ b/skills/generate-cases/SKILL.md
@@ -11,6 +11,7 @@ This skill helps you to generate comprehensive test cases and checklists for sof
 
 - [Testomat.io TMS Guide](./references/testomat-tms-guide.md) - Complete guide for Testomat.io compatibility
 - [Test Case Format](./references/test-case-format.md) - Test cases markdown format reference (testomatio-friendly)
+- [Writing Rules](./references/writing-rule.md) - Rules for writing test suites, test cases, preconditions, and steps (incl. AI writing patterns to avoid)
 
 ## When to Use
 
@@ -323,9 +324,12 @@ If user prompted checklist generation only (not test cases), ask user if he want
 - **Be adaptable**. Adjust depth, detail, testing type and other parameters based on user feedback.
 - **Keep scope**. Test only the functionality under test but not the related entities. If feature linked to other features, don't test them if user didn't ask for it explicitly.
 
-**Follow test case writing rules**: `./references/test-case-format.md`
+**Follow test case writing rules**:
 
-Always use provided Test case format
+- Format: `./references/test-case-format.md`
+- Content/style rules (suites, tests, preconditions, steps, anti-patterns): `./references/writing-rule.md`
+
+Always use provided Test case format and writing rules.
 
 **Don't change the user's source code. Only generate `*.test.md` files with test cases.**
 
@@ -348,6 +352,8 @@ Checklist should have hierarchical and categorized structure.
 ### Test cases format (saved to .md file(s))
 
 - Strictly follow the `./references/test-case-format.md` format. Exception: user specify format in the prompt. In this case, follow the user's format.
+
+- Strictly follow the writing rules from `./references/writing-rule.md` (suite/test descriptions, preconditions, step structure, expected results, anti-patterns).
 
 - Follow [Testomat.io TMS Guide](./references/testomat-tms-guide.md) for format and conventions (priority levels, tags, labels, etc.) (especially when using testomatio mcp)
 

--- a/skills/generate-cases/SKILL.md
+++ b/skills/generate-cases/SKILL.md
@@ -31,6 +31,8 @@ Trigger this skill when the user:
 
 ### User interaction
 
+- Strictly recommend user to use "PLAN" mode. Switch to "Edit" mode only on last step – writing test cases to md files.
+
 - When user interaction required, good to highlight it with question mark emoji ❓. Example:
 
 ```
@@ -55,7 +57,9 @@ This skill follows an **iterative approach**.
 **Don't omit steps and strictly ask for user approval/feedback before proceeding to the next step**.
 Generate **checklist** prior to **test cases** generation even if user request sounds like "generate test cases".
 
-WHEN AVAILABLE USE ASK TOOL WHEN ASKING USER FOR INPUT WITH CHOICES
+**When available use Ask tool when asking user for input with choices.**
+
+**Ask user for clarification if you are not sure about something, don't suggest.**
 
 ### Workflow Steps
 

--- a/skills/generate-cases/references/test-case-format.md
+++ b/skills/generate-cases/references/test-case-format.md
@@ -135,9 +135,9 @@ Test steps use the `## Steps` header section with a nested markdown list format:
 ## Steps
 
 - (Step Action)
-  _Expected_: ... (Observable behavior)
+  *Expected:* ... (Observable behavior)
 - ...
-  _Expected_: ...
+  *Expected:* ...
 ```
 
 **Step format rules:**
@@ -200,11 +200,11 @@ A user should be able to log in with valid credentials.
 ## Steps
 
 - Navigate to the login page
-  _Expected_: Login form is displayed with username and password fields
+  *Expected:* Login form is displayed with username and password fields
 - Enter a valid username and password
-  _Expected_: Credentials are entered without errors
+  *Expected:* Credentials are entered without errors
 - Click the "Login" button
-  _Expected_: User is redirected to the dashboard
+  *Expected:* User is redirected to the dashboard
 
 <!-- example -->
 
@@ -238,17 +238,17 @@ Verify that a new user can successfully register with valid information.
 ## Steps
 
 - Navigate to the registration page
-  _Expected_: Registration form is displayed
+  *Expected:* Registration form is displayed
 - Enter a valid email address
-  _Expected_: Email is accepted and passes validation
+  *Expected:* Email is accepted and passes validation
 - Enter a strong password (8+ characters with uppercase, lowercase, and numbers)
-  _Expected_: Password meets complexity requirements
+  *Expected:* Password meets complexity requirements
 - Confirm the password
-  _Expected_: Passwords match
+  *Expected:* Passwords match
 - Accept the Terms of Service
-  _Expected_: Checkbox is selected
+  *Expected:* Checkbox is selected
 - Click the "Register" button
-  _Expected_: Success message is displayed and user is redirected to welcome page
+  *Expected:* Success message is displayed and user is redirected to welcome page
 ```
 
 ### Test with numbered steps
@@ -275,11 +275,11 @@ Verify that a new user can be created via POST request.
 ## Steps
 
 1. Send POST request to `/api/users` with valid user data
-   _Expected_: Response status code is 201
+   *Expected:* Response status code is 201
 2. Verify response contains user ID and created timestamp
-   _Expected_: Response includes `id` and `createdAt` fields
+   *Expected:* Response includes `id` and `createdAt` fields
 3. Send GET request to `/api/users/{id}` to retrieve the created user
-   _Expected_: User data matches the data sent in POST request
+   *Expected:* User data matches the data sent in POST request
 ```
 
 ### Test with complex nested steps
@@ -307,21 +307,21 @@ Verify that a user can complete the checkout process with multiple items in the 
 ## Steps
 
 - Add multiple products to the cart
-  _Expected_: All products appear in the cart with correct quantities and prices
+  *Expected:* All products appear in the cart with correct quantities and prices
 - Proceed to checkout
-  _Expected_: Checkout page loads with shipping address form
+  *Expected:* Checkout page loads with shipping address form
 - Fill in valid shipping address details
-  _Expected_: Form validation passes and shows no errors
+  *Expected:* Form validation passes and shows no errors
 - Select a shipping method
-  _Expected_: Shipping cost is calculated and displayed
+  *Expected:* Shipping cost is calculated and displayed
 - Select a payment method
-  _Expected_: Payment form is displayed (or guest checkout option)
+  *Expected:* Payment form is displayed (or guest checkout option)
 - Complete the payment process
-  _Expected_: Payment is processed successfully
+  *Expected:* Payment is processed successfully
 - Verify order confirmation
-  _Expected_: Order confirmation page is displayed with order number and summary
+  *Expected:* Order confirmation page is displayed with order number and summary
 - Check email for order confirmation
-  _Expected_: Confirmation email is received with matching order details
+  *Expected:* Confirmation email is received with matching order details
 ```
 
 ### Test with tags in title

--- a/skills/generate-cases/references/test-case-format.md
+++ b/skills/generate-cases/references/test-case-format.md
@@ -135,9 +135,9 @@ Test steps use the `## Steps` header section with a nested markdown list format:
 ## Steps
 
 - (Step Action)
-  *Expected:* ... (Observable behavior)
+  *Expected*: ... (Observable behavior)
 - ...
-  *Expected:* ...
+  *Expected*: ...
 ```
 
 **Step format rules:**
@@ -200,11 +200,11 @@ A user should be able to log in with valid credentials.
 ## Steps
 
 - Navigate to the login page
-  *Expected:* Login form is displayed with username and password fields
+  *Expected*: Login form is displayed with username and password fields
 - Enter a valid username and password
-  *Expected:* Credentials are entered without errors
+  *Expected*: Credentials are entered without errors
 - Click the "Login" button
-  *Expected:* User is redirected to the dashboard
+  *Expected*: User is redirected to the dashboard
 
 <!-- example -->
 
@@ -238,17 +238,17 @@ Verify that a new user can successfully register with valid information.
 ## Steps
 
 - Navigate to the registration page
-  *Expected:* Registration form is displayed
+  *Expected*: Registration form is displayed
 - Enter a valid email address
-  *Expected:* Email is accepted and passes validation
+  *Expected*: Email is accepted and passes validation
 - Enter a strong password (8+ characters with uppercase, lowercase, and numbers)
-  *Expected:* Password meets complexity requirements
+  *Expected*: Password meets complexity requirements
 - Confirm the password
-  *Expected:* Passwords match
+  *Expected*: Passwords match
 - Accept the Terms of Service
-  *Expected:* Checkbox is selected
+  *Expected*: Checkbox is selected
 - Click the "Register" button
-  *Expected:* Success message is displayed and user is redirected to welcome page
+  *Expected*: Success message is displayed and user is redirected to welcome page
 ```
 
 ### Test with numbered steps
@@ -275,11 +275,11 @@ Verify that a new user can be created via POST request.
 ## Steps
 
 1. Send POST request to `/api/users` with valid user data
-   *Expected:* Response status code is 201
+   *Expected*: Response status code is 201
 2. Verify response contains user ID and created timestamp
-   *Expected:* Response includes `id` and `createdAt` fields
+   *Expected*: Response includes `id` and `createdAt` fields
 3. Send GET request to `/api/users/{id}` to retrieve the created user
-   *Expected:* User data matches the data sent in POST request
+   *Expected*: User data matches the data sent in POST request
 ```
 
 ### Test with complex nested steps
@@ -307,21 +307,21 @@ Verify that a user can complete the checkout process with multiple items in the 
 ## Steps
 
 - Add multiple products to the cart
-  *Expected:* All products appear in the cart with correct quantities and prices
+  *Expected*: All products appear in the cart with correct quantities and prices
 - Proceed to checkout
-  *Expected:* Checkout page loads with shipping address form
+  *Expected*: Checkout page loads with shipping address form
 - Fill in valid shipping address details
-  *Expected:* Form validation passes and shows no errors
+  *Expected*: Form validation passes and shows no errors
 - Select a shipping method
-  *Expected:* Shipping cost is calculated and displayed
+  *Expected*: Shipping cost is calculated and displayed
 - Select a payment method
-  *Expected:* Payment form is displayed (or guest checkout option)
+  *Expected*: Payment form is displayed (or guest checkout option)
 - Complete the payment process
-  *Expected:* Payment is processed successfully
+  *Expected*: Payment is processed successfully
 - Verify order confirmation
-  *Expected:* Order confirmation page is displayed with order number and summary
+  *Expected*: Order confirmation page is displayed with order number and summary
 - Check email for order confirmation
-  *Expected:* Confirmation email is received with matching order details
+  *Expected*: Confirmation email is received with matching order details
 ```
 
 ### Test with tags in title

--- a/skills/generate-cases/references/writing-rule.md
+++ b/skills/generate-cases/references/writing-rule.md
@@ -106,7 +106,9 @@ Avoid using commas, sub-sentences.
 Steps are mechanical: click, send, read, assert.
 Each step must include exact instructions
 Prefer placeholder variable names like `${domain}` or `${company-title}` over specific values.
-Prefer using URL paths over full urls If its url path, e.g. `${domain}/auth/login`.
+Do not add as placeholders data which is not specifically related to test. 
+Do not add preconditions as placeholders.
+Prefer using URL paths over full urls If its url path, e.g. `/auth/login`.
 Use specific values when they are important for the scenario (e.g. boundary values, format validation, locale-specific input).
 Avoid vague qualifiers like "small", "known", "around", "e.g.", "like", "(…)"; replace them with concrete placeholders or, when required, literal values.
 Avoid general statements in steps. Move general statements to the description.

--- a/skills/generate-cases/references/writing-rule.md
+++ b/skills/generate-cases/references/writing-rule.md
@@ -2,14 +2,11 @@
 
 Important: Refer to user provided test cases first, then use these rules.
 
-
 Formulas, business rules, edge-case reasoning, and feature context live in the suite/test description.
 Prerequisites which are common to all test cases must be written as bullet points in the suite description.
 Formulas, diagrams, relavant to all test cases can be included as codeblocks in the suite description.
 
-
 ## Test Case Writing Rules
-
 
 Test case consist of description and steps
 Add the intent of the test case to the description if title is not fully enough to explain the intent.
@@ -17,14 +14,13 @@ Description must be clear and concise.
 Focus on blackbox testing, thus each operation and observable results must be obtained via public apis or UI (unless user specifies otherwise).
 Prefer using UI (frondend tests) over public apis when possible.
 Ask user for app url and credentials, or frontend repo url to understand the application and its components.
-Understand UI pages and components or API endpoints from source code or design or requirements. 
+Understand UI pages and components or API endpoints from source code or design or requirements.
 Add system checks only if it not clear how to test via public apis or UI.
 It is not a unit test, usually no direct server or code access is allowed.
 
-"Why" in description, "what" in steps. 
+"Why" in description, "what" in steps.
 
 Put preparations into **preconditions**/**description** section, not as steps.
-
 
 ## Title
 
@@ -49,14 +45,12 @@ Good vs bad:
 - Bad: `Login and update profile` → Good: split into two tests
 - Bad: `Email validation` → Good: `User sees error when email format is invalid`
 
-
-## Preconditions  
+## Preconditions
 
 Do not include preconditions like "service is running" if it's not explicitly mentioned by user or is not actually what the test is about.
 Define the pre-conditions and initial state of the system as bullet points.
 Avoid if not needed or is the same as the suite description.
 If relevant, include the user role
-
 
 ## Steps
 
@@ -81,12 +75,21 @@ You may add a codeblock after a step if needed to:
 - to illustrate the point using pseudocode
 - etc
 
+If expected result has multiple conditions split them into separate lines:
+
+Instead of:
+_Expected:_ Comment appears in the Run's comment list with the current user as author\*
+
+Use:
+_Expected:_ Comment appears in the Run's comment list
+_Expected:_ Current user is the author
+
 ### Bold and italic in steps
 
 Use sparingly. Each style serves one purpose; otherwise write plain text.
 
 - **bold** — UI elements the user interacts with: buttons, links, fields, tabs, checkboxes, modals (e.g. `Click **Save**`, `Open **Settings** tab`).
-- *italic* — step labels (`*Action:*`, `*Expected:*`, `*Precondition:*`, `*Note:*`) and names of pages/screens/documents referenced as context (e.g. `Open the *Privacy Policy* page`).
+- _italic_ — step labels (`*Action:*`, `*Expected:*`, `*Precondition:*`, `*Note:*`) and names of pages/screens/documents referenced as context (e.g. `Open the *Privacy Policy* page`).
 
 Avoid:
 
@@ -94,16 +97,6 @@ Avoid:
 - Combining bold and italic (`***...***`).
 - Emphasis for visual weight; rephrase or split the step instead.
 - Bold/italic in place of a placeholder (`[url]`) or a code block.
-
-If expected result has multiple conditions split them into separate lines:
-
-Instead of:
-  *Expected:* Comment appears in the Run's comment list with the current user as author*
-
-Use:
-  *Expected:* Comment appears in the Run's comment list
-  *Expected:* Current user is the author
-
 
 ## AI Writing Patterns to Avoid
 

--- a/skills/generate-cases/references/writing-rule.md
+++ b/skills/generate-cases/references/writing-rule.md
@@ -27,23 +27,23 @@ Put preparations into **preconditions**/**description** section, not as steps.
 Title states the behavior under test from the user's perspective.
 
 - Pattern: `User can <action> <object> <qualifier>` for positive cases; `User cannot ...`, `User sees <error>`, or `System rejects ...` for negative cases.
-- Sentence case, no trailing period, single intent, concise (~80 chars max).
+- Sentence case, no trailing period, single intent, ~80 chars max.
 - Prefer concrete qualifiers ("with valid email", "with empty password") over vague ones ("correctly", "properly").
 
 Avoid:
 
 - Filler prefixes: `Verify that ...`, `Test that ...`, `Check ...`, `Should ...`
-- Multi-intent titles joined by `and` / `then`: `User logs in and updates profile`
+- Multi-intent titles joined by `and` / `then`
 - Restating the suite name in every title
 - Embedding IDs or numbers: `TC-001: Login`
 - Vague outcomes: `Successful login`, `Login works`
 
 Good vs bad:
 
-- Bad: `Verify successful login` → Good: `User can log in with valid email and password`
-- Bad: `Wrong password test` → Good: `User cannot log in with invalid password`
-- Bad: `Login and update profile` → Good: split into two tests
-- Bad: `Email validation` → Good: `User sees error when email format is invalid`
+- `Verify successful login` → `User can log in with valid email and password`
+- `Wrong password test` → `User cannot log in with invalid password`
+- `Login and update profile` → split into two tests
+- `Email validation` → `User sees error when email format is invalid`
 
 ## Preconditions
 

--- a/skills/generate-cases/references/writing-rule.md
+++ b/skills/generate-cases/references/writing-rule.md
@@ -65,9 +65,9 @@ Each step must be simple sentences.
 Avoid using commas, subsentances
 Steps are mechanical: click, send, read, assert.
 Each step must include exact instructions
-Prefer steps that include specific values, urls
-Prefer concrete values over general words. Replace "small", "known", "around", "e.g.", "like", "(…)" with literal numbers, strings, etc. 
-If no values are availble use placholders variable names like `${url}` or `${company-title}`
+Prefer placeholder variable names like `[url]` or `[company-title]` over specific values
+Use specific values when they are important for the scenario (e.g. boundary values, format validation, locale-specific input).
+Avoid vague qualifiers like "small", "known", "around", "e.g.", "like", "(…)"; replace them with concrete placeholders or, when required, literal values.
 Avoid general statements in steps. Move general statements to the description.
 Do not chain multiple distinct actions or use unnecessary And / Or combinations in a single sequence.
 All step actions must be clear to perform via PUBLIC API or UI

--- a/skills/generate-cases/references/writing-rule.md
+++ b/skills/generate-cases/references/writing-rule.md
@@ -8,17 +8,20 @@ Formulas, diagrams, relavant to all test cases can be included as codeblocks in 
 
 ## Test Case Writing Rules
 
-Test case consist of description and steps
+Test case consist of description and steps.
 Add the intent of the test case to the description if title is not fully enough to explain the intent.
 Description must be clear and concise.
-Focus on blackbox testing, thus each operation and observable results must be obtained via public apis or UI (unless user specifies otherwise).
-Prefer using UI (frondend tests) over public apis when possible.
-Ask user for app url and credentials, or frontend repo url to understand the application and its components.
-Understand UI pages and components or API endpoints from source code or design or requirements.
-Add system checks only if it not clear how to test via public apis or UI.
-It is not a unit test, usually no direct server or code access is allowed.
+Focus on black-box testing, thus each operation and observable results must be obtained via public apis or UI (unless user specifies otherwise).
+Prefer using UI over public apis when possible.
+**If this is a web app** ask user to discover it
+- by looking its frontend source code
+- by accessing it on non-production environment via browser (URLs and credentials)
+- by looking at screenshots of related pages
+  Understand UI pages and components or API endpoints from source code or design or requirements.
+  Add system checks only if it not clear how to test via public apis or UI.
+  It is not a unit test, usually no direct server or code access is allowed.
 
-"Why" in description, "what" in steps.
+Golden rule: "Why" in description, "what" in steps.
 
 Put preparations into **preconditions**/**description** section, not as steps.
 
@@ -26,9 +29,17 @@ Put preparations into **preconditions**/**description** section, not as steps.
 
 Title states the behavior under test from the user's perspective.
 
-- Pattern: `User can <action> <object> <qualifier>` for positive cases; `User cannot ...`, `User sees <error>`, or `System rejects ...` for negative cases.
-- Sentence case, no trailing period, single intent, ~80 chars max.
-- Prefer concrete qualifiers ("with valid email", "with empty password") over vague ones ("correctly", "properly").
+Title structure: "<role> <action> <object> <qualifier>"
+
+Examples:
+
+- Editor can change description of a blogpost in admin panel
+- User can report a bug using widget on a web page
+- Blocked user must not be able to log in into app workspace
+- Admin can invite up to 10 user to a project via Settings Page
+- User can not edit a comment it doesn't own
+- User can retry operation when NetworkError occurs
+- User can not retry operation when network connection is disabled
 
 Avoid:
 
@@ -47,20 +58,55 @@ Good vs bad:
 
 ## Preconditions
 
+Add preconditions for actions which do not belong to actions, but are required for the test to run.
 Do not include preconditions like "service is running" if it's not explicitly mentioned by user or is not actually what the test is about.
 Define the pre-conditions and initial state of the system as bullet points.
 Avoid if not needed or is the same as the suite description.
-If relevant, include the user role
+If relevant, include the user role.
 
 ## Steps
 
+````suggestion
 Step should consist of **action** (with optional test data) and **expected result**.
+
+Test steps use the `## Steps` header section with a nested markdown list format:
+
+```markdown
+## Steps
+
+* (Step Action)
+  *Expected*: ... (Observable behavior)
+* ...
+  *Expected*: ...
+````
+
+e.g.
+
+```markdown
+## Steps
+
+- Navigate to the login page
+  *Expected*: Login form is displayed with username and password fields
+- Enter a valid username and password
+  *Expected*: Credentials are entered without errors
+- Click the "Login" button
+  *Expected*: User is redirected to the dashboard
+```
+
+Step format rules:
+
+Steps must be under a `## Steps` heading
+Use nested markdown lists (bulleted * or numbered 1.)
+Top-level items describe the action to perform
+Nested items with *Expected* (or *Expected*:, *Expected result\*) describe the observable behavior
+Expected results should be specific and verifiable
+
 Each step must be simple sentences.
-Avoid using commas, subsentances
+Avoid using commas, sub-sentences.
 Steps are mechanical: click, send, read, assert.
 Each step must include exact instructions
-Prefer placeholder variable names like `[url]` or `[company-title]` over specific values.
-If its url path – use specific values, e.g. `[url]/auth/login`.
+Prefer placeholder variable names like `${domain}` or `${company-title}` over specific values.
+Prefer using URL paths over full urls If its url path, e.g. `${domain}/auth/login`.
 Use specific values when they are important for the scenario (e.g. boundary values, format validation, locale-specific input).
 Avoid vague qualifiers like "small", "known", "around", "e.g.", "like", "(…)"; replace them with concrete placeholders or, when required, literal values.
 Avoid general statements in steps. Move general statements to the description.
@@ -78,18 +124,20 @@ You may add a codeblock after a step if needed to:
 If expected result has multiple conditions split them into separate lines:
 
 Instead of:
-_Expected:_ Comment appears in the Run's comment list with the current user as author\*
+
+`*Expected*: Comment appears in the Run's comment list with the current user as author`
 
 Use:
-_Expected:_ Comment appears in the Run's comment list
-_Expected:_ Current user is the author
+
+`*Expected*: Comment appears in the Run's comment list`
+`*Expected*: Current user is the author`
 
 ### Bold and italic in steps
 
 Use sparingly. Each style serves one purpose; otherwise write plain text.
 
 - **bold** — UI elements the user interacts with: buttons, links, fields, tabs, checkboxes, modals (e.g. `Click **Save**`, `Open **Settings** tab`).
-- _italic_ — step labels (`*Action:*`, `*Expected:*`, `*Precondition:*`, `*Note:*`) and names of pages/screens/documents referenced as context (e.g. `Open the *Privacy Policy* page`).
+- *italic* — names of pages/screens/documents referenced as context (e.g. `Open the *Privacy Policy* page`).
 
 Avoid:
 

--- a/skills/generate-cases/references/writing-rule.md
+++ b/skills/generate-cases/references/writing-rule.md
@@ -1,27 +1,25 @@
 ## Test Suite Writing Rules
 
 
-Formulas, business rules, edge-case reasoning, and feature
-context live in the suite/test description.
+Formulas, business rules, edge-case reasoning, and feature context live in the suite/test description.
 Prerequisites which are common to all test cases must be written as bullet points in the suite description.
 Formulas, diagrams, relavant to all test cases can be included as codeblocks in the suite description.
 
 
 ## Test Case Writing Rules
 
-Describe the intent of the test case.
-Intent is needed only if title is not fully enough to explain the intent.
 
 Test case consist of description and steps
+Add the intent of the test case to the description if title is not fully enough to explain the intent.
 Description must be clear and concise.
-Focus on whitebox testing, thus each operation and observable results must be obtained via public apis or UI.
-Prefer using UI over public apis when possible.
-If you think UI is available, and test can be achived from UI, test must use it
+Focus on blackbox testing, thus each operation and observable results must be obtained via public apis or UI (unless user specifies otherwise).
+Prefer using UI (frondend tests) over public apis when possible.
+Ask user for app url and credentials, or frontend repo url to understand the application and its components.
 Understand UI pages and components or API endpoints from source code or design or requirements. 
 Add system checks only if it not clear how to test via public apis or UI.
 It is not a unit test, usually no direct server or code access is allowed.
 
-Why in description, what in steps. 
+"Why" in description, "what" in steps. 
 
 Put preparations into **preconditions**/**description** section, not as steps.
 

--- a/skills/generate-cases/references/writing-rule.md
+++ b/skills/generate-cases/references/writing-rule.md
@@ -1,5 +1,7 @@
 ## Test Suite Writing Rules
 
+Important: Refer to user provided test cases first, then use these rules.
+
 
 Formulas, business rules, edge-case reasoning, and feature context live in the suite/test description.
 Prerequisites which are common to all test cases must be written as bullet points in the suite description.
@@ -22,6 +24,30 @@ It is not a unit test, usually no direct server or code access is allowed.
 "Why" in description, "what" in steps. 
 
 Put preparations into **preconditions**/**description** section, not as steps.
+
+
+## Title
+
+Title states the behavior under test from the user's perspective.
+
+- Pattern: `User can <action> <object> <qualifier>` for positive cases; `User cannot ...`, `User sees <error>`, or `System rejects ...` for negative cases.
+- Sentence case, no trailing period, single intent, concise (~80 chars max).
+- Prefer concrete qualifiers ("with valid email", "with empty password") over vague ones ("correctly", "properly").
+
+Avoid:
+
+- Filler prefixes: `Verify that ...`, `Test that ...`, `Check ...`, `Should ...`
+- Multi-intent titles joined by `and` / `then`: `User logs in and updates profile`
+- Restating the suite name in every title
+- Embedding IDs or numbers: `TC-001: Login`
+- Vague outcomes: `Successful login`, `Login works`
+
+Good vs bad:
+
+- Bad: `Verify successful login` → Good: `User can log in with valid email and password`
+- Bad: `Wrong password test` → Good: `User cannot log in with invalid password`
+- Bad: `Login and update profile` → Good: split into two tests
+- Bad: `Email validation` → Good: `User sees error when email format is invalid`
 
 
 ## Preconditions  

--- a/skills/generate-cases/references/writing-rule.md
+++ b/skills/generate-cases/references/writing-rule.md
@@ -65,13 +65,14 @@ Each step must be simple sentences.
 Avoid using commas, subsentances
 Steps are mechanical: click, send, read, assert.
 Each step must include exact instructions
-Prefer placeholder variable names like `[url]` or `[company-title]` over specific values
+Prefer placeholder variable names like `[url]` or `[company-title]` over specific values.
+If its url path – use specific values, e.g. `[url]/auth/login`.
 Use specific values when they are important for the scenario (e.g. boundary values, format validation, locale-specific input).
 Avoid vague qualifiers like "small", "known", "around", "e.g.", "like", "(…)"; replace them with concrete placeholders or, when required, literal values.
 Avoid general statements in steps. Move general statements to the description.
 Do not chain multiple distinct actions or use unnecessary And / Or combinations in a single sequence.
 All step actions must be clear to perform via PUBLIC API or UI
-All checks/verifications/assertions should be in **expected result**, not as separate steps.
+All checks/verifications/assertions should be in **expected result**, not as step **action**.
 You may add a codeblock after a step if needed to:
 
 - write API request
@@ -80,7 +81,19 @@ You may add a codeblock after a step if needed to:
 - to illustrate the point using pseudocode
 - etc
 
-Avoid using bold/italic formatting in steps.
+### Bold and italic in steps
+
+Use sparingly. Each style serves one purpose; otherwise write plain text.
+
+- **bold** — UI elements the user interacts with: buttons, links, fields, tabs, checkboxes, modals (e.g. `Click **Save**`, `Open **Settings** tab`).
+- *italic* — step labels (`*Action:*`, `*Expected:*`, `*Precondition:*`, `*Note:*`) and names of pages/screens/documents referenced as context (e.g. `Open the *Privacy Policy* page`).
+
+Avoid:
+
+- Bold/italic on full sentences or whole steps.
+- Combining bold and italic (`***...***`).
+- Emphasis for visual weight; rephrase or split the step instead.
+- Bold/italic in place of a placeholder (`[url]`) or a code block.
 
 If expected result has multiple conditions split them into separate lines:
 

--- a/skills/generate-cases/references/writing-rule.md
+++ b/skills/generate-cases/references/writing-rule.md
@@ -70,31 +70,16 @@ Use:
 
 ## AI Writing Patterns to Avoid
 
+Be specific, not grandiose. Say what it actually does. Avoid marketing language and emojis (unless explicitly intended).
+
 Avoid:
 
-Puffery: pivotal, crucial, vital, testament, enduring legacy
-Empty "-ing" phrases: ensuring reliability, showcasing features, highlighting capabilities
-Promotional adjectives: groundbreaking, seamless, robust, cutting-edge
-Overused AI vocabulary: delve, leverage, multifaceted, foster, realm, tapestry
-Formatting overuse: excessive bullets, emoji decorations, bold on every other word
-
-Be specific, not grandiose. Say what it actually does. Avoid marketing language.
-
-
-Words to watch: stands/serves as, is a testament/reminder, plays a vital/significant/crucial/pivotal role, underscores/highlights its importance/significance, reflects broader, symbolizing its ongoing/enduring/lasting impact, key turning point, indelible mark, deeply rooted, profound heritage, steadfast dedication...
-
-Words to watch: ensuring ..., highlighting ..., emphasizing ..., reflecting ..., underscoring ..., showcasing ..., aligns with..., contributing to...
-
-Words to watch: continues to captivate, groundbreaking (in the figurative sense), stunning natural beauty, enduring/lasting legacy, nestled, in the heart of, boasts a...
-
-Words to watch: it's important/critical/crucial to note/remember/consider, may vary...
-
-Words to watch: In summary, In conclusion, Overall...
-
-Words to watch: Despite its... faces several challenges..., Despite these challenges, Challenges and Legacy, Future Outlook...
-
-Words to watch: align/aligns/aligning with,68 crucial,1 delve/delves/delving (pre-2025),681 emphasizing,68 enduring,8 enhance/enhances/enhancing,81 fostering,81 garnered/garnering,68 highlight/highlighted/highlighting/highlights (as a verb),1 interplay,8 intricate/intricacies,687 key (as an adjective), landscape,8 leveraging,1 multifaceted,687 notably,8 nuanced,68 realm,8 robust,1 seamless/seamlessly,1 shed light on, showcasing,8 streamline,1 tapestry,8 testament,18 underpin/underpins/underpinning,8 underscore/underscores/underscoring,8 vibrant,87 vital,1 ...
-
-Parallel constructions involving "not", "but", or "however" such as "Not only ... but ..." or "It is not just about ..., it's ..." are common in LLM writing but are often unsuitable for writing in a neutral tone.
-
-Avoid using emojis if not explicitly intended.
+- Puffery: pivotal, crucial, vital, testament, enduring legacy, indelible mark, deeply rooted, profound heritage, steadfast dedication, key turning point
+- Promotional adjectives: groundbreaking (figurative), seamless/seamlessly, robust, cutting-edge, vibrant, nuanced, multifaceted, intricate/intricacies, stunning natural beauty
+- Overused AI vocabulary: delve/delves, leverage/leveraging, foster/fostering, realm, tapestry, landscape, interplay, streamline, shed light on, garnered, notably, key (as adjective)
+- Empty "-ing" phrases: ensuring, showcasing, highlighting, emphasizing, reflecting, underscoring, aligning with, contributing to, enhancing, underpinning
+- Filler frames: stands/serves as, is a testament/reminder, plays a vital/significant/crucial/pivotal role, underscores/highlights its importance, reflects broader, symbolizing its ongoing/enduring/lasting impact, continues to captivate, nestled in the heart of, boasts a
+- Hedges and closers: it's important/critical/crucial to note/remember/consider, may vary, In summary, In conclusion, Overall
+- "Challenges/Legacy" framing: Despite its... faces several challenges, Despite these challenges, Challenges and Legacy, Future Outlook
+- Parallel "not/but/however" constructions: "Not only ... but ...", "It is not just about ..., it's ..." — common in LLM writing but unsuitable for a neutral tone
+- Formatting overuse: excessive bullets, emoji decorations, bold on every other word


### PR DESCRIPTION
-  make "avoid" patterns concise
- add reference to writing rules file
- focus on FE testing
- propagate "asking" instead of "suggesting"
- "Plan" mode recommendation
- improve writing rules
- enforce BDD TC title style (add rules with examples)
- update rules for specific values usage
- add bold/italic writing rules
- concise output for user in terminal