### PR TITLE
Fix/generation paths

### DIFF
--- a/skills/automation-coverage/SKILL.md
+++ b/skills/automation-coverage/SKILL.md
@@ -30,7 +30,7 @@ This skill works **only with automated e2e tests** (Playwright, Cypress, Webdriv
 - **DO NOT** process unit tests.
 - **DO NOT** process manual markdown test cases (use `manual-coverage` instead - if already exists).
 - **DO NOT** suggest creating new tests.
-- **Only touch two files in this repo.** It may write `coverage.e2e.yml` (or the path the user gave) and add one `.testclaw-context/` line to `.gitignore` if it is missing. Nothing else — never a source or test file. If the e2e tests live in another repo, clone it into the gitignored `.testclaw-context/e2e-tests/`, never into a tracked folder (see Step 1).
+- **Only touch two files in this repo.** It may write `coverage.e2e.yml` (or the path the user gave) and add one `.testclaw/` line to `.gitignore` if it is missing. Nothing else — never a source or test file. If the e2e tests live in another repo, clone it into the gitignored `.testclaw/e2e-tests/`, never into a tracked folder (see Step 1).
 - **Don't write scripts. Never use Python.** Read test files with your file tool; pull out IDs and tags with `grep` (Step 3). To check the finished coverage file, pipe it through `js-yaml` into the one tiny bundled helper (symlinked from `manual-coverage`): `npx js-yaml coverage.e2e.yml | node scripts/check-coverage.mjs` (Step 6). That's the only script. If you ever need more than a `grep`, a one-line `node -e '…'` is the limit — never `python`, never a parser of your own.
 
 ---
@@ -46,10 +46,10 @@ From the `project-scan` result, capture:
 - **Automated Tests** — the list of e2e test files (the input to Step 3).
 - **Project Overview** — languages, complexity (the framing for Step 5).
 
-If `project-scan` reports **no automated tests** (it checks `.testclaw-context/e2e-tests/` too, so this means nothing was cloned before), or no e2e framework is detected:
+If `project-scan` reports **no automated tests** (it checks `.testclaw/e2e-tests/` too, so this means nothing was cloned before), or no e2e framework is detected:
 - ❓ Ask the user to either:
   1. Give the path to the e2e tests (then re-run `project-scan` there).
-  2. Give the git URL of the e2e tests repo → `git clone <url> .testclaw-context/e2e-tests`, add `.testclaw-context/` to `.gitignore` if missing, and re-run `project-scan` against `.testclaw-context/e2e-tests`.
+  2. Give the git URL of the e2e tests repo → `git clone <url> .testclaw/e2e-tests`, add `.testclaw/` to `.gitignore` if missing, and re-run `project-scan` against `.testclaw/e2e-tests`.
   3. Stop.
 
 Never clone the tests into a tracked folder in this repo.
@@ -87,7 +87,7 @@ For each test file extract:
 - **Tags** — other `@word` markers (`@smoke`, `@jira-123`, `@regression`).
 - **What is exercised** — page objects imported, routes hit, fixtures used — used to reason about which source files each test covers.
 
-**How to extract.** Read the test files, or `grep` for the IDs and tags in test/suite names. Run these in whichever directory holds the tests (`tests/e2e`, or the cache `.testclaw-context/e2e-tests`):
+**How to extract.** Read the test files, or `grep` for the IDs and tags in test/suite names. Run these in whichever directory holds the tests (`tests/e2e`, or the cache `.testclaw/e2e-tests`):
 
 ```bash
 grep -rnoE '@[ST][0-9a-f]{8}' <dir>             # suite/test IDs (+ which file/line)
@@ -163,7 +163,7 @@ npx js-yaml coverage.e2e.yml | node scripts/check-coverage.mjs
 
 `npx js-yaml` parses the file (and fails loudly if the YAML is malformed, so a broken file never reaches the script). `check-coverage.mjs` then flags any key whose path is missing on disk, any key with no identifiers, and prints every `@S…` / `@T…` / tag it references. Check that list against the IDs you extracted in Step 3 — only you know which are real. Don't re-parse the test files; use the set you already have. Never use `python`.
 
-> The keys in the coverage file are paths to source files in this repo, never `.testclaw-context/...` paths. The cache holds the cloned tests; the coverage file points at the code they exercise.
+> The keys in the coverage file are paths to source files in this repo, never `.testclaw/...` paths. The cache holds the cloned tests; the coverage file points at the code they exercise.
 
 Then show the produced YAML to the user.
 
@@ -225,7 +225,7 @@ It's the only script — everything else is `grep`, your file tool, or `npx js-y
 
 ### Recovery
 
-- **No e2e tests found (cache included)** → ask for the path, or a git URL to clone into the gitignored `.testclaw-context/e2e-tests/`.
+- **No e2e tests found (cache included)** → ask for the path, or a git URL to clone into the gitignored `.testclaw/e2e-tests/`.
 - **Tests have no `@S`/`@T` IDs** → instruct the user to run `npx check-tests <Framework> "<glob>" --update-ids` (cross-link `reporter-setup`).
 - **Ambiguous source layout** → ask which directories are application code.
 

--- a/skills/generate-cases/SKILL.md
+++ b/skills/generate-cases/SKILL.md
@@ -22,6 +22,12 @@ Trigger this skill when the user:
 - Shares designs (Figma, Miro, screenshots, etc.) and wants test coverage
 - Mentions QA activities or testing documentation needs
 
+### Prerequisites
+
+- You already checked the project structure and identified what is the in this folder (source code, e2e tests, test cases) using /project-scan skill
+- You pulled existing Testomat.io tests using /sync-cases skill
+- You have switched to PLAN MODE if availble to start interview section
+
 ### User interaction
 
 - When user interaction required, good to highlight it with question mark emoji ❓. Example:
@@ -47,6 +53,8 @@ Trigger this skill when the user:
 This skill follows an **iterative approach**.
 **Don't omit steps and strictly ask for user approval/feedback before proceeding to the next step**.
 Generate **checklist** prior to **test cases** generation even if user request sounds like "generate test cases".
+
+WHEN AVAILABLE USE ASK TOOL WHEN ASKING USER FOR INPUT WITH CHOICES
 
 ### Workflow Steps
 
@@ -156,6 +164,8 @@ I've gathered information from the following sources:
 1. ➡️ Go to next step
 2. ✏️ Type changes
 ```
+
+You must also look for existing test cases to avoid duplicating test cases. If existing test cases found report this to user and suggest expanding them or creating a new suite.
 
 [Wait for user approval before proceeding to Step 2.]
 
@@ -301,24 +311,21 @@ Example:
 
 ### Step 5: Generate Detailed Test Cases
 
+
 **Proceed with this step only after user approval of checklist.**
 
 If user prompted checklist generation only (not test cases), ask user if he wants to generate test cases (e.g. **"Do you want to generate test cases for this checklist?"**) or proceed to test case generation.
 
-Rules:
-
 - If multiple features to test or whole product => put generated test cases of each feature in separate file.
-- Step should consist of **action** (with optional test data) and **expected result**.
-- All checks/verifications/assertions should be in **expected result**, not as separate steps.
-- **Be thorough but practical**. Cover important scenarios without overwhelming detail (unless user asks for it or select appropriate role e.g. "nerd").
-- **Use clear language**. Test steps should be unambiguous and easy to follow.
+- - **Be thorough but practical**. Cover important scenarios without overwhelming detail (unless user asks for it or select appropriate role e.g. "nerd").
 - If user provides **existing test cases**, follow their **style**.
-- **Think like a tester**. Consider not just what works, but what could break.
 - **Consider the user**. Focus on user-facing functionality first.
 - **Be adaptable**. Adjust depth, detail, testing type and other parameters based on user feedback.
 - **Keep scope**. Test only the functionality under test but not the related entities. If feature linked to other features, don't test them if user didn't ask for it explicitly.
-- Do not include **preconditions** like "service is running" if it's not explicitly mentioned by user or is not actually what the test is about.
-- Put preparations into **preconditions**/**description** section, not as steps.
+
+**Follow test case writing rules**: `./references/test-case-format.md`
+
+Always use provided Test case format
 
 **Don't change the user's source code. Only generate `*.test.md` files with test cases.**
 
@@ -348,6 +355,9 @@ Checklist should have hierarchical and categorized structure.
 - **IMPORTANT:** **Strictly follow the `./references/test-case-format.md` format** for **suites**, **tests** and **steps**.
 - Use `<!-- suite ... -->` and `<!-- test ... -->` blocks to wrap test cases.
 - If required, put `tags:` and `labels:` inside **each** `<!-- test ... -->` metadata block (see [test metadata](./references/test-case-format.md#test-metadata)). Not only on the suite block.
+- Try to reuse existing tags and labels obtained by MCP or from other test cases. 
+- Variables and placeholders always must be formatted as `${variable}` or `${placeholder}` (use backticks).
+- Do not use labels if you are not aware of any existing ones.
 - If reasonable, add test metadata like priority, preconditions, test data, labels, tags based on analyzed information and context.
 - **IMPORTANT: NEVER GENERATE test or suite IDs of ANY kind**:
   - Do NOT include Testomat.io IDs (`id: @T*`, `id: @S*`, e.g. `@T12345678`, `@S380c64db`).

--- a/skills/generate-cases/SKILL.md
+++ b/skills/generate-cases/SKILL.md
@@ -311,6 +311,11 @@ Example:
 
 ### Step 5: Generate Detailed Test Cases
 
+Where to store test cases?
+
+- If this workspace is empty or is for manual-tests only, test cases must be generated in root
+- If this is end-to-end testing project test cases must be generated in `manual-tests` directory
+- In any other case test cases must be generated in `.testclaw/manual-tests` (ensure `.testclaw` directory exists and git ignored)
 
 **Proceed with this step only after user approval of checklist.**
 

--- a/skills/generate-cases/references/writing-rule.md
+++ b/skills/generate-cases/references/writing-rule.md
@@ -1,0 +1,100 @@
+## Test Suite Writing Rules
+
+
+Formulas, business rules, edge-case reasoning, and feature
+context live in the suite/test description.
+Prerequisites which are common to all test cases must be written as bullet points in the suite description.
+Formulas, diagrams, relavant to all test cases can be included as codeblocks in the suite description.
+
+
+## Test Case Writing Rules
+
+Describe the intent of the test case.
+Intent is needed only if title is not fully enough to explain the intent.
+
+Test case consist of description and steps
+Description must be clear and concise.
+Focus on whitebox testing, thus each operation and observable results must be obtained via public apis or UI.
+Prefer using UI over public apis when possible.
+If you think UI is available, and test can be achived from UI, test must use it
+Understand UI pages and components or API endpoints from source code. If source code not availble ask user for it.
+Add system checks only if it not clear how to test via public apis or UI.
+It is not a unit test, usually no direct server or code access is allowed.
+
+Why in description, what in steps. 
+
+Put preparations into **preconditions**/**description** section, not as steps.
+
+
+## Preconditions  
+
+Do not include preconditions like "service is running" if it's not explicitly mentioned by user or is not actually what the test is about.
+Define the pre-conditions and initial state of the system as bullet points.
+Avoid if not needed or is the same as the suite description.
+If relevant, include the user role
+
+
+## Steps
+
+Step should consist of **action** (with optional test data) and **expected result**.
+Each step must be simple sentences.
+Avoid using commas, subsentances
+Steps are mechanical: click, send, read, assert.
+Each step must include exact instructions
+Prefer steps that include specific values, urls
+Prefer concrete values over general words. Replace "small", "known", "around", "e.g.", "like", "(…)" with literal numbers, strings, etc. 
+If no values are availble use placholders variable names like `${url}` or `${company-title}`
+Avoid general statements in steps. Move general statements to the description.
+Do not chain multiple distinct actions or use unnecessary And / Or combinations in a single sequence.
+All step actions must be clear to perform via PUBLIC API or UI
+All checks/verifications/assertions should be in **expected result**, not as separate steps.
+You may add a codeblock after a step if needed to:
+
+- write API request
+- write SQL
+- write shell command
+- to illustrate the point using pseudocode
+- etc
+
+Avoid using bold/italic formatting in steps.
+
+If expected result has multiple conditions split them into separate lines:
+
+Instead of:
+  *Expected:* Comment appears in the Run's comment list with the current user as author*
+
+Use:
+  *Expected:* Comment appears in the Run's comment list
+  *Expected:* Current user is the author
+
+
+## AI Writing Patterns to Avoid
+
+Avoid:
+
+Puffery: pivotal, crucial, vital, testament, enduring legacy
+Empty "-ing" phrases: ensuring reliability, showcasing features, highlighting capabilities
+Promotional adjectives: groundbreaking, seamless, robust, cutting-edge
+Overused AI vocabulary: delve, leverage, multifaceted, foster, realm, tapestry
+Formatting overuse: excessive bullets, emoji decorations, bold on every other word
+
+Be specific, not grandiose. Say what it actually does. Avoid marketing language.
+
+
+Words to watch: stands/serves as, is a testament/reminder, plays a vital/significant/crucial/pivotal role, underscores/highlights its importance/significance, reflects broader, symbolizing its ongoing/enduring/lasting impact, key turning point, indelible mark, deeply rooted, profound heritage, steadfast dedication...
+
+Words to watch: ensuring ..., highlighting ..., emphasizing ..., reflecting ..., underscoring ..., showcasing ..., aligns with..., contributing to...
+
+Words to watch: continues to captivate, groundbreaking (in the figurative sense), stunning natural beauty, enduring/lasting legacy, nestled, in the heart of, boasts a...
+
+Words to watch: it's important/critical/crucial to note/remember/consider, may vary...
+
+Words to watch: In summary, In conclusion, Overall...
+
+Words to watch: Despite its... faces several challenges..., Despite these challenges, Challenges and Legacy, Future Outlook...
+
+Words to watch: align/aligns/aligning with,68 crucial,1 delve/delves/delving (pre-2025),681 emphasizing,68 enduring,8 enhance/enhances/enhancing,81 fostering,81 garnered/garnering,68 highlight/highlighted/highlighting/highlights (as a verb),1 interplay,8 intricate/intricacies,687 key (as an adjective), landscape,8 leveraging,1 multifaceted,687 notably,8 nuanced,68 realm,8 robust,1 seamless/seamlessly,1 shed light on, showcasing,8 streamline,1 tapestry,8 testament,18 underpin/underpins/underpinning,8 underscore/underscores/underscoring,8 vibrant,87 vital,1 ...
+
+Parallel constructions involving "not", "but", or "however" such as "Not only ... but ..." or "It is not just about ..., it's ..." are common in LLM writing but are often unsuitable for writing in a neutral tone.
+
+Avoid using emojis if not explicitly intended.

--- a/skills/manual-coverage/SKILL.md
+++ b/skills/manual-coverage/SKILL.md
@@ -29,7 +29,7 @@ This skill works **only with manual tests in markdown format**.
 
 - **DO NOT** process unit, functional, or e2e test files.
 - **DO NOT** suggest creating new automated tests.
-- **Only touch two files in this repo.** This skill runs inside the user's source-code repo. It may write `coverage.manual.yml` (or the path the user gave) and add one `.testclaw-context/` line to `.gitignore` if it is missing. Nothing else — never a source file. Cases pulled from Testomat.io go into the gitignored `.testclaw-context/manual-tests/`, never into a tracked folder (see Step 1).
+- **Only touch two files in this repo.** This skill runs inside the user's source-code repo. It may write `coverage.manual.yml` (or the path the user gave) and add one `.testclaw/` line to `.gitignore` if it is missing. Nothing else — never a source file. Cases pulled from Testomat.io go into the gitignored `.testclaw/manual-tests/`, never into a tracked folder (see Step 1).
 - **Don't write scripts. Never use Python.** Read `.test.md` files with your file tool; pull out IDs and tags with `grep` (Step 2). To check the finished coverage file, pipe it through `js-yaml` into the one tiny bundled helper: `npx js-yaml coverage.manual.yml | node scripts/check-coverage.mjs` (Step 5). If more checks needed use custom script with `npx js-yaml`.
 
 If automated test files (e.g. e2e test, unit, api)  are encountered while exploring, ignore them and continue with the manual markdown set.
@@ -49,7 +49,7 @@ From the `project-scan` result, capture:
 
 If `project-scan` reports **no manual tests** (it checks the cache too, so this means nothing was pulled before):
 - ❓ Ask the user how to proceed:
-  1. Pull cases from Testomat.io — have **`sync-cases`** pull into the gitignored cache: `npx check-tests pull -d .testclaw-context/manual-tests`, then add `.testclaw-context/` to `.gitignore` if missing. Re-run `project-scan` and continue.
+  1. Pull cases from Testomat.io — have **`sync-cases`** pull into the gitignored cache: `npx check-tests pull -d .testclaw/manual-tests`, then add `.testclaw/` to `.gitignore` if missing. Re-run `project-scan` and continue.
   2. Point to a directory the scan missed (then re-run `project-scan` there).
   3. Stop.
 
@@ -64,7 +64,7 @@ Each manual test markdown file follows the format described in [Classical Tests 
 - **Tags** — `@tag` markers in suite/test titles and `tags:` lines inside the metadata blocks.
 - **Context** — suite title, test titles, steps, and expected results — used to reason about which source files implement each behavior.
 
-**How to extract.** Read the `.test.md` files — the metadata blocks are short. For a quick overview, `grep` instead of a parser. Run these in whichever directory holds the cases (`manual-tests/`, or the cache `.testclaw-context/manual-tests/`):
+**How to extract.** Read the `.test.md` files — the metadata blocks are short. For a quick overview, `grep` instead of a parser. Run these in whichever directory holds the cases (`manual-tests/`, or the cache `.testclaw/manual-tests/`):
 
 ```bash
 grep -rnE 'id:[[:space:]]*@S' <dir>      # suite IDs (+ which file)
@@ -146,7 +146,7 @@ npx js-yaml coverage.manual.yml | node scripts/check-coverage.mjs
 
 `npx js-yaml` parses the file (and fails loudly if the YAML is malformed, so a broken file never reaches the script). `check-coverage.mjs` then flags any key whose path is missing on disk, any key with no identifiers, and prints every `@S…` / `@T…` / tag it references. Check that list against the IDs you extracted in Step 2 — only you know which are real. Don't re-parse the markdown; use the set you already have. Never use `python`.
 
-> The keys in the coverage file are paths to source files in this repo, never `.testclaw-context/...` paths. The cache holds the test cases; the coverage file points at the code they cover.
+> The keys in the coverage file are paths to source files in this repo, never `.testclaw/...` paths. The cache holds the test cases; the coverage file points at the code they cover.
 
 Then show the produced YAML to the user.
 
@@ -171,7 +171,7 @@ TESTOMATIO_RUNGROUP="Regression 911" npx @testomatio/reporter run \
 
 Recommend committing `coverage.manual.yml` to the repository so CI and teammates use the same mapping.
 
-If you pulled the cases, tell the user they stay in the gitignored `.testclaw-context/manual-tests/`. A re-run or a follow-up question reuses them, and nothing was committed. Don't delete the cache or move it into a tracked folder.
+If you pulled the cases, tell the user they stay in the gitignored `.testclaw/manual-tests/`. A re-run or a follow-up question reuses them, and nothing was committed. Don't delete the cache or move it into a tracked folder.
 
 ### Step 7: Suggest follow-ups
 
@@ -179,8 +179,8 @@ Once the file is saved, propose any of:
 
 - Scan the source for **coverage gaps** (features without manual tests). On approval, propose new manual cases (delegate to `generate-cases`).
 - Scan for **dead tests** (manual tests whose features no longer exist in source).
-- Answer questions like "do we have manual tests for X?" from the cached cases in `.testclaw-context/manual-tests/`.
-- If the user wants to *edit* cases, they can edit them right in `.testclaw-context/manual-tests/` and push back with `sync-cases` — gitignored doesn't mean read-only.
+- Answer questions like "do we have manual tests for X?" from the cached cases in `.testclaw/manual-tests/`.
+- If the user wants to *edit* cases, they can edit them right in `.testclaw/manual-tests/` and push back with `sync-cases` — gitignored doesn't mean read-only.
 
 ---
 
@@ -207,7 +207,7 @@ It's the only script — everything else is `grep`, your file tool, or `npx js-y
 
 ### Recovery
 
-- **No manual tests found (cache included)** → have `sync-cases` pull into `.testclaw-context/manual-tests/`, or ask the user for a directory the scan missed.
+- **No manual tests found (cache included)** → have `sync-cases` pull into `.testclaw/manual-tests/`, or ask the user for a directory the scan missed.
 - **Markdown files with no `@S`/`@T` IDs** → ask whether to push first via `sync-cases`, or skip those files.
 - **Ambiguous source layout** → ask the user which directories are application code.
 
@@ -225,7 +225,7 @@ It's the only script — everything else is `grep`, your file tool, or `npx js-y
 ```
 Use manual-coverage skill to build coverage.manual.yml for our manual cases
 ```
-If there are no local `.test.md` files, it pulls them into the gitignored `.testclaw-context/manual-tests/` and works from there.
+If there are no local `.test.md` files, it pulls them into the gitignored `.testclaw/manual-tests/` and works from there.
 
 **Cases already local:**
 ```
@@ -238,7 +238,7 @@ Use manual-coverage skill, output to ops/coverage.qa.yml
 ```
 
 **Full workflow (source repo):**
-1. `manual-coverage` runs `project-scan`. No local cases, so it has `sync-cases` pull into `.testclaw-context/manual-tests/` (gitignored) and re-runs `project-scan`.
+1. `manual-coverage` runs `project-scan`. No local cases, so it has `sync-cases` pull into `.testclaw/manual-tests/` (gitignored) and re-runs `project-scan`.
 2. It maps source files to suite/test/tag IDs and writes `coverage.manual.yml`. The only tracked changes are that file and one line in `.gitignore`.
 3. `npx @testomatio/reporter run --kind manual --filter "coverage:file=coverage.manual.yml,diff=main"` creates a pending run with only the affected cases.
 
@@ -248,6 +248,6 @@ Use manual-coverage skill, output to ops/coverage.qa.yml
 
 | Action                                 | Command                                                                                              |
 | -------------------------------------- | ---------------------------------------------------------------------------------------------------- |
-| Pull cases into the gitignored cache  | `npx check-tests pull -d .testclaw-context/manual-tests`                                            |
+| Pull cases into the gitignored cache  | `npx check-tests pull -d .testclaw/manual-tests`                                            |
 | Create affected manual run             | `npx @testomatio/reporter run --kind manual --filter "coverage:file=coverage.manual.yml,diff=main"`  |
 | Group runs                             | `TESTOMATIO_RUNGROUP="Regression 911" npx @testomatio/reporter run --kind manual --filter "..."`     |

--- a/skills/project-scan/SKILL.md
+++ b/skills/project-scan/SKILL.md
@@ -54,27 +54,29 @@ Where is the source code?
 ```
 [Waits for the user's reply.]
 
-- If user provides `Git repo` or `another folder` variant => clone or symlink it into `.testclaw-context/code/` (see the rule below). No-op if it's already there.
+- If user provides `Git repo` or `another folder` variant => clone or symlink it into `.testclaw/code/` (see the rule below). No-op if it's already there.
 
-#### Rule for pulled data — `.testclaw-context/`
+#### Rule for pulled data — `.testclaw/`
 
-**This applies to every skill, not just `project-scan`.**
+Detect if we are inside a git repo, skip this rule if not.
+In this case we must be strict about additional data we need to collect.
+It is highly recommended to pull all required data into `.testclaw/` by any testomatio skill.
 
 1. First, see what's already in the current folder.
-2. If you need data that isn't here — manual test cases, the application code, e2e tests, a repo to clone — pull it into `.testclaw-context/` (gitignored). **Never** pull it into a regular folder like `manual-tests/` or `automated-tests/`; that pollutes the repo.
-3. If the data is already in the repo, use it where it is — you don't need `.testclaw-context/` for that.
+2. If you need data that isn't here — manual test cases, the application code, files for requirements, e2e tests, a repo to clone — pull it into `.testclaw/` (gitignored). **Never** pull it into current workspace folder
+3. If the data is already in the repo, use it where it is — you don't need `.testclaw/` for that.
 
 | When you run inside…    | What you'd pull in…  | Goes in…                          |
 | ----------------------- | -------------------- | --------------------------------- |
-| a source-code repo      | manual test cases    | `.testclaw-context/manual-tests/` |
-| a manual-tests repo     | the application code | `.testclaw-context/code/`         |
-| (e2e tests in own repo) | the e2e tests        | `.testclaw-context/e2e-tests/`    |
+| a source-code repo      | manual test cases    | `.testclaw/manual-tests/` |
+| a manual-tests repo     | the application code | `.testclaw/code/`         |
+| (e2e tests in own repo) | the e2e tests        | `.testclaw/e2e-tests/`    |
 
-Any skill that creates `.testclaw-context/...` must also add `.testclaw-context/` to the project's `.gitignore` — but only if it is not there yet. Never add it twice.
+Any skill that creates `.testclaw/...` must also add `.testclaw/` to the project's `.gitignore` — but only if it is not there yet. Never add it twice.
 
 (The rule is about *pulled* data. Output a skill *produces* and the user wants — a `coverage.*.yml`, new `*.test.md` files — goes in the repo as normal.)
 
-On a source repo with no manual tests, `project-scan` changes no tracked file: it only creates the gitignored `.testclaw-context/` directory and, if needed, adds one line to `.gitignore`.
+On a source repo with no manual tests, `project-scan` changes no tracked file: it only creates the gitignored `.testclaw/` directory and, if needed, adds one line to `.gitignore`.
 
 ---
 
@@ -97,7 +99,7 @@ Exclude:
 - Dependencies (e.g. `node_modules/`, `vendor/`, `.venv/`).
 - Build/generated output (e.g. `dist/`, `build/`, `.next/`, `target/`).
 - Coverage, reports, caches, config, lock, and environment files.
-- Ignored paths from `.gitignore` — but **not** `.testclaw-context/code/`. In a manual-tests repo the app code lives there, so scan it as source even though `.testclaw-context/` is gitignored.
+- Ignored paths from `.gitignore` — but **not** `.testclaw/code/`. In a manual-tests repo the app code lives there, so scan it as source even though `.testclaw/` is gitignored.
 - TestClaw internal files (e.g. `session-factory.ts`, `system-prompt.ts`).
 [**If in doubt**, prefer excluding over including non-source files.]
 
@@ -175,7 +177,7 @@ For each detected framework:
 
 ### Manual Tests
 
-Find all `.test.md` files and parse test titles. `find .` also looks inside `.testclaw-context/manual-tests/`, so a re-run after a pull finds the cached cases instead of reporting "no manual tests":
+Find all `.test.md` files and parse test titles. `find .` also looks inside `.testclaw/manual-tests/`, so a re-run after a pull finds the cached cases instead of reporting "no manual tests":
 
 ```bash
 find . -name "*.test.md" -exec awk '
@@ -191,7 +193,7 @@ find . -name "*.test.md" -exec awk '
 ' {} +
 ```
 
-If the only `.test.md` files are under `.testclaw-context/manual-tests/`, say so in the inventory: they came from Testomat.io, not from this repo.
+If the only `.test.md` files are under `.testclaw/manual-tests/`, say so in the inventory: they came from Testomat.io, not from this repo.
 
 ---
 

--- a/skills/project-scan/SKILL.md
+++ b/skills/project-scan/SKILL.md
@@ -54,7 +54,7 @@ Where is the source code?
 ```
 [Waits for the user's reply.]
 
-- If user provides `Git repo` or `another folder` variant => Check if cache directory `.testclaw-context/code` already exists. If not, create it and save files or symlink to this `code/` folder.
+- If user provides `Git repo` or `another folder` variant => Check if cache directory `.testclaw/code` already exists. If not, create it and save files or symlink to this `code/` folder.
 *The command is a no-op when the directory already exists.*
 
 ---
@@ -305,4 +305,3 @@ Skill Output:
 
 > No automation tests found in the project.
 ```
-

--- a/skills/sync-cases/SKILL.md
+++ b/skills/sync-cases/SKILL.md
@@ -3,7 +3,7 @@ name: sync-cases
 description: Synchronize test scenarios and cases between a local project and Testomat.io. Use this skill whenever the user wants to pull/export/download tests from Testomat.io; or push/import/sync new or updated test cases back to the TMS in corresponding `*.test.md` format. Supports custom directories, markdown test format and advanced import/export workflows.
 inputs:
   testDir:
-    description: "Target directory for pulled tests (default: `manual-tests`)"
+    description: "Target directory for pulled tests"
     required: false
 license: MIT
 metadata:
@@ -76,17 +76,23 @@ Download/Retrieves test scenarios from Testomat.io and saves them as Markdown fi
 - Refactor test cases offline.
 
 **Pre-Pull:**
-- Ensure `testDir` exists; otherwise create `manual-tests` folder in root.
+
+- If `testDir` is specified pull tests into it. Otherwise:
+- If this workspace is empty or is for manual-tests only, test must be pulled to root
+- If this is end-to-end testing project test cases must be generated in `manual-tests` directory
+- In any other case test cases must be pulled to `.testclaw/manual-tests` (ensure `.testclaw` directory exists and git ignored)
 
 **Command:**
 ```bash
 npx check-tests pull -d <directory>
 ```
 
+
+
 **Examples:**
 ```bash
 # Pull tests to default manual-tests folder
-npx check-tests pull -d manual-tests
+npx check-tests pull -d .testclaw/manual-tests
 ```
 
 **More examples** you can find in "Pull" section [Testomat.io CLI Documentation](./references/TESTOMATIO_CLI.md)
@@ -104,15 +110,8 @@ Uploads/Imports local Markdown tests into Testomat.io:
 
 **Pre-Push File Filtering**
 
-Before uploading, scan the project/target folder and **include only**:
-- Files matching `*.test.md` pattern.
-- Files containing valid test blocks: `<!-- test ... -->` markers.
+If directory contains manual test cases + something else, move test cases into `.testclaw/manual-tests`
 
-**Exclude** all other `.md` files — especially:
-- `README.md`, `CHANGELOG.md`, `CONTRIBUTING.md`.
-- Project documentation (`docs/requirements.md`, `architecture.md`, etc.).
-
-> If a directory contains mixed content, skip documentation files and upload only test case files.
 
 **Pre-Push Validation:**
 1. Ensure at least one test `*.test.md` file exists.
@@ -141,30 +140,29 @@ npx check-tests push [-d <directory>] [--files <files...>]
 **Examples:**
 ```bash
 # Specific files (preferred when known)
-npx check-tests push --files manual-tests/login.test.md manual-tests/checkout.test.md
+npx check-tests push --files login.test.md checkout.test.md
 
 # Custom glob
-npx check-tests push --files "manual-tests/**/*.test.md"
+npx check-tests push --files "**/*.test.md"
 
 # Default glob (**/*.test.md) under -d
-npx check-tests push -d manual-tests
+npx check-tests push
+
+# Specify directory with manual test cases
+npx check-tests push -d .testclaw/manual-tests
+
+# Specify directory with manual test cases and specific files
+npx check-tests push -d .testclaw/manual-tests --files new_tests.md
 ```
 
 **Important constraints:**
 - Only use options explicitly documented in this skill or in the "Testomat.io CLI Documentation" ref file.
 - If you are unsure about available CLI options, run `npx check-tests --help` and use only options listed there.
 - Do **not** use an option unless it is mentioned in the documentation or in the `--help` option (e.g., `--pattern`, `--forces`).
+- Ensure you use -d when `.testclaw` or `manual-tests` directories exist. 
+- Ensure you push only the test cases directory (e.g `.testclaw/manual-tests` not `.testclaw`).
 
 **More examples** you can find in "Push" section [Testomat.io CLI Documentation](./references/TESTOMATIO_CLI.md)
-
-#### Labels Handling (Intent-Based)
-
-Use `TESTOMATIO_LABELS` in sync/push **only if the user explicitly requests to set or override labels** in their query.
-
-**Triggers:**
-* "push tests with labels smoke".
-* "import tests to TMS and set label=regression":
-  - labels like `smoke,regression` example: `TESTOMATIO_LABELS="smoke,regression" npx check-tests push`
 
 ---
 

--- a/skills/sync-cases/SKILL.md
+++ b/skills/sync-cases/SKILL.md
@@ -76,7 +76,7 @@ Download/Retrieves test scenarios from Testomat.io and saves them as Markdown fi
 - Refactor test cases offline.
 - Export only some specific suites by id.
 
-**Where to pull:** into the gitignored cache `.testclaw-context/manual-tests/`, and add `.testclaw-context/` to the project `.gitignore` if it is not there yet. Pulled cases must never land in a tracked folder (`manual-tests/`, etc.) — that pollutes the repo. You can still edit them there and push back; being gitignored doesn't stop that. (If the repo *already* keeps its `*.test.md` files in a tracked folder, you don't need to pull at all — work with them where they are, or pass `-d <that folder>` for an in-place refresh.) This matches `project-scan`, which pulls the *code* into `.testclaw-context/code/` when it runs inside a manual-tests repo.
+**Where to pull:** into the gitignored cache `.testclaw/manual-tests/`, and add `.testclaw/` to the project `.gitignore` if it is not there yet. Pulled cases must never land in a tracked folder (`manual-tests/`, etc.) — that pollutes the repo. You can still edit them there and push back; being gitignored doesn't stop that. (If the repo *already* keeps its `*.test.md` files in a tracked folder, you don't need to pull at all — work with them where they are, or pass `-d <that folder>` for an in-place refresh.) This matches `project-scan`, which pulls the *code* into `.testclaw/code/` when it runs inside a manual-tests repo.
 
 **Pre-Pull:**
 
@@ -102,7 +102,7 @@ Optional variant - **pull by specific suite-ids**
 **Pull Examples:**
 ```bash
 # Default — pull into the gitignored cache
-npx check-tests pull -d .testclaw-context/manual-tests
+npx check-tests pull -d .testclaw/manual-tests
 
 # Repo that already keeps its test cases tracked — refresh them in place
 npx check-tests pull -d manual-tests
@@ -189,7 +189,7 @@ After completing sync operations, output a short log-style summary:
 ```
 Sync Complete:
 - Action: pull/push
-- Directory: .testclaw-context/manual-tests
+- Directory: .testclaw/manual-tests
 - Tests synced: 15
 - Status: Success
 ```
@@ -227,7 +227,7 @@ Stop execution if:
 
 ## Examples
 
-**Pull tests** (lands in the gitignored `.testclaw-context/manual-tests/`):
+**Pull tests** (lands in the gitignored `.testclaw/manual-tests/`):
 ```
 Use sync-cases skill to pull tests from Testomat.io
 ```


### PR DESCRIPTION
Replaced `.testclaw-context` with `.testclaw` 
added a new instructions for testclaw dir management