### PR TITLE
qa-write-test-cases: don't parametrize first-pass test cases

### DIFF
--- a/skills/qa-write-test-cases/SKILL.md
+++ b/skills/qa-write-test-cases/SKILL.md
@@ -371,7 +371,7 @@ Checklist should have hierarchical and categorized structure.
 - Use `<!-- suite ... -->` and `<!-- test ... -->` blocks to wrap test cases.
 - If required, put `tags:` and `labels:` inside **each** `<!-- test ... -->` metadata block (see [test metadata](./references/test-case-format.md#test-metadata)). Not only on the suite block.
 - Try to reuse existing tags and labels obtained by MCP or from other test cases. 
-- Variables and placeholders always must be formatted as `${variable}` or `${placeholder}` (use backticks).
+- Use concrete, executable values by default — do NOT introduce `${...}` placeholders in first-pass generation. Only parametrize a value when it is genuinely reused or data-driven; if you do, format it as `${variable}` or `${placeholder}` (use backticks).
 - Do not use labels if you are not aware of any existing ones.
 - If reasonable, add test metadata like priority, preconditions, test data, labels, tags based on analyzed information and context.
 - **IMPORTANT: NEVER GENERATE test or suite IDs of ANY kind**:

--- a/skills/qa-write-test-cases/references/writing-rule.md
+++ b/skills/qa-write-test-cases/references/writing-rule.md
@@ -105,12 +105,13 @@ Each step must be simple sentences.
 Avoid using commas, sub-sentences.
 Steps are mechanical: click, send, read, assert.
 Each step must include exact instructions
-Prefer placeholder variable names like `${domain}` or `${company-title}` over specific values.
+Prefer concrete, realistic values a tester can act on directly. Do NOT parametrize by default — first-pass test cases should read as executable manual steps, not templates.
+Use a placeholder variable like `${domain}` only when the value is genuinely reused across steps or is data-driven (see the Examples section in the format reference). A plain UI/API acceptance step needs concrete values, not placeholders.
 Do not add as placeholders data which is not specifically related to test. 
 Do not add preconditions as placeholders.
 Prefer using URL paths over full urls If its url path, e.g. `/auth/login`.
 Use specific values when they are important for the scenario (e.g. boundary values, format validation, locale-specific input).
-Avoid vague qualifiers like "small", "known", "around", "e.g.", "like", "(…)"; replace them with concrete placeholders or, when required, literal values.
+Avoid vague qualifiers like "small", "known", "around", "e.g.", "like", "(…)"; replace them with concrete, literal values.
 Avoid general statements in steps. Move general statements to the description.
 Do not chain multiple distinct actions or use unnecessary And / Or combinations in a single sequence.
 All step actions must be clear to perform via PUBLIC API or UI


### PR DESCRIPTION
## Problem

When generating manual test cases, the agent over-parametrized everything — turning concrete tester actions into `${...}` template shells. The resulting cases read as templates, not executable manual steps (real complaint that triggered this fix).

Root cause is in the **`qa-write-test-cases`** skill's writing rules:

- `references/writing-rule.md` — *"Prefer placeholder variable names like `${domain}` ... over specific values."*
- `SKILL.md` — *"Variables and placeholders always must be formatted as `${...}`."*

For a plain UI/API acceptance suite there's no data-driven dimension, so the model applied the "prefer placeholders" rule globally. The nearby guardrails ("don't placeholder non-test data", "use specific values when important") were too weak to counter the dominant *prefer placeholders* instruction.

## Change

Flip the default for first-pass generation:

- **Prefer concrete, realistic values** a tester can act on directly; do not parametrize by default.
- Use a `${...}` placeholder **only** when the value is genuinely reused across steps or is data-driven (the optional Examples table remains the place for real parametrization).
- `SKILL.md`: same default — keep the `${...}` formatting convention only for when a variable is actually warranted.
- Removed the "replace with concrete **placeholders**" nudge from the vague-qualifiers rule → now "concrete, **literal** values".

No behavior change for genuinely data-driven cases — the Examples-table mechanism is untouched.