### PR TITLE
[CACHE FOLDER] Use .testeiya/ cache folder as default location if exist

### DIFF
--- a/skills/e2e-test-coverage-mapping/SKILL.md
+++ b/skills/e2e-test-coverage-mapping/SKILL.md
@@ -30,7 +30,7 @@ This skill works **only with automated e2e tests** (Playwright, Cypress, Webdriv
 - **DO NOT** process unit tests.
 - **DO NOT** process manual markdown test cases (use `qa-manual-tests-to-code-coverage` instead - if already exists).
 - **DO NOT** suggest creating new tests.
-- **Only touch two files in this repo.** It may write `coverage.e2e.yml` (or the path the user gave) and add one `.testclaw/` line to `.gitignore` if it is missing. Nothing else — never a source or test file. If the e2e tests live in another repo, clone it into the gitignored `.testclaw/e2e-tests/`, never into a tracked folder (see Step 1).
+- **Only touch two files in this repo.** It may write `coverage.e2e.yml` (or the path the user gave) and add one `.testeiya/` line to `.gitignore` if it is missing. Nothing else — never a source or test file. If the e2e tests live in another repo, clone it into the gitignored `.testeiya/e2e-tests/`, never into a tracked folder (see Step 1).
 - **Don't write scripts. Never use Python.** Read test files with your file tool; pull out IDs and tags with `grep` (Step 3). To check the finished coverage file, pipe it through `js-yaml` into the one tiny bundled helper (symlinked from `qa-manual-tests-to-code-coverage`): `npx js-yaml coverage.e2e.yml | node scripts/check-coverage.mjs` (Step 6). That's the only script. If you ever need more than a `grep`, a one-line `node -e '…'` is the limit — never `python`, never a parser of your own.
 
 ---
@@ -46,10 +46,10 @@ From the `scan-automation-project` result, capture:
 - **Automated Tests** — the list of e2e test files (the input to Step 3).
 - **Project Overview** — languages, complexity (the framing for Step 5).
 
-If `scan-automation-project` reports **no automated tests** (it checks `.testclaw/e2e-tests/` too, so this means nothing was cloned before), or no e2e framework is detected:
+If `scan-automation-project` reports **no automated tests** (it checks `.testeiya/e2e-tests/` too, so this means nothing was cloned before), or no e2e framework is detected:
 - ❓ Ask the user to either:
   1. Give the path to the e2e tests (then re-run `scan-automation-project` there).
-  2. Give the git URL of the e2e tests repo → `git clone <url> .testclaw/e2e-tests`, add `.testclaw/` to `.gitignore` if missing, and re-run `scan-automation-project` against `.testclaw/e2e-tests`.
+  2. Give the git URL of the e2e tests repo → `git clone <url> .testeiya/e2e-tests`, add `.testeiya/` to `.gitignore` if missing, and re-run `scan-automation-project` against `.testeiya/e2e-tests`.
   3. Stop.
 
 Never clone the tests into a tracked folder in this repo.
@@ -87,7 +87,7 @@ For each test file extract:
 - **Tags** — other `@word` markers (`@smoke`, `@jira-123`, `@regression`).
 - **What is exercised** — page objects imported, routes hit, fixtures used — used to reason about which source files each test covers.
 
-**How to extract.** Read the test files, or `grep` for the IDs and tags in test/suite names. Run these in whichever directory holds the tests (`tests/e2e`, or the cache `.testclaw/e2e-tests`):
+**How to extract.** Read the test files, or `grep` for the IDs and tags in test/suite names. Run these in whichever directory holds the tests (`tests/e2e`, or the cache `.testeiya/e2e-tests`):
 
 ```bash
 grep -rnoE '@[ST][0-9a-f]{8}' <dir>             # suite/test IDs (+ which file/line)
@@ -163,7 +163,7 @@ npx js-yaml coverage.e2e.yml | node scripts/check-coverage.mjs
 
 `npx js-yaml` parses the file (and fails loudly if the YAML is malformed, so a broken file never reaches the script). `check-coverage.mjs` then flags any key whose path is missing on disk, any key with no identifiers, and prints every `@S…` / `@T…` / tag it references. Check that list against the IDs you extracted in Step 3 — only you know which are real. Don't re-parse the test files; use the set you already have. Never use `python`.
 
-> The keys in the coverage file are paths to source files in this repo, never `.testclaw/...` paths. The cache holds the cloned tests; the coverage file points at the code they exercise.
+> The keys in the coverage file are paths to source files in this repo, never `.testeiya/...` paths. The cache holds the cloned tests; the coverage file points at the code they exercise.
 
 Then show the produced YAML to the user.
 
@@ -225,7 +225,7 @@ It's the only script — everything else is `grep`, your file tool, or `npx js-y
 
 ### Recovery
 
-- **No e2e tests found (cache included)** → ask for the path, or a git URL to clone into the gitignored `.testclaw/e2e-tests/`.
+- **No e2e tests found (cache included)** → ask for the path, or a git URL to clone into the gitignored `.testeiya/e2e-tests/`.
 - **Tests have no `@S`/`@T` IDs** → instruct the user to run `npx check-tests <Framework> "<glob>" --update-ids` (cross-link `qa-e2e-tests-reporting`).
 - **Ambiguous source layout** → ask which directories are application code.
 

--- a/skills/qa-manual-tests-to-code-coverage/SKILL.md
+++ b/skills/qa-manual-tests-to-code-coverage/SKILL.md
@@ -29,7 +29,7 @@ This skill works **only with manual tests in markdown format**.
 
 - **DO NOT** process unit, functional, or e2e test files.
 - **DO NOT** suggest creating new automated tests.
-- **Only touch two files in this repo.** This skill runs inside the user's source-code repo. It may write `coverage.manual.yml` (or the path the user gave) and add one `.testclaw/` line to `.gitignore` if it is missing. Nothing else — never a source file. Cases pulled from Testomat.io go into the gitignored `.testclaw/manual-tests/`, never into a tracked folder (see Step 1).
+- **Only touch two files in this repo.** This skill runs inside the user's source-code repo. It may write `coverage.manual.yml` (or the path the user gave) and add one `.testeiya/` line to `.gitignore` if it is missing. Nothing else — never a source file. Cases pulled from Testomat.io go into the gitignored `.testeiya/manual-tests/`, never into a tracked folder (see Step 1).
 - **Don't write scripts. Never use Python.** Read `.test.md` files with your file tool; pull out IDs and tags with `grep` (Step 2). To check the finished coverage file, pipe it through `js-yaml` into the one tiny bundled helper: `npx js-yaml coverage.manual.yml | node scripts/check-coverage.mjs` (Step 5). If more checks needed use custom script with `npx js-yaml`.
 
 If automated test files (e.g. e2e test, unit, api)  are encountered while exploring, ignore them and continue with the manual markdown set.
@@ -49,7 +49,7 @@ From the `scan-automation-project` result, capture:
 
 If `scan-automation-project` reports **no manual tests** (it checks the cache too, so this means nothing was pulled before):
 - ❓ Ask the user how to proceed:
-  1. Pull cases from Testomat.io — have **`sync-test-cases-with-tms`** pull into the gitignored cache: `npx check-tests pull -d .testclaw/manual-tests`, then add `.testclaw/` to `.gitignore` if missing. Re-run `scan-automation-project` and continue.
+  1. Pull cases from Testomat.io — have **`sync-test-cases-with-tms`** pull into the gitignored cache: `npx check-tests pull -d .testeiya/manual-tests`, then add `.testeiya/` to `.gitignore` if missing. Re-run `scan-automation-project` and continue.
   2. Point to a directory the scan missed (then re-run `scan-automation-project` there).
   3. Stop.
 
@@ -64,7 +64,7 @@ Each manual test markdown file follows the format described in [Classical Tests 
 - **Tags** — `@tag` markers in suite/test titles and `tags:` lines inside the metadata blocks.
 - **Context** — suite title, test titles, steps, and expected results — used to reason about which source files implement each behavior.
 
-**How to extract.** Read the `.test.md` files — the metadata blocks are short. For a quick overview, `grep` instead of a parser. Run these in whichever directory holds the cases (`manual-tests/`, or the cache `.testclaw/manual-tests/`):
+**How to extract.** Read the `.test.md` files — the metadata blocks are short. For a quick overview, `grep` instead of a parser. Run these in whichever directory holds the cases (`manual-tests/`, or the cache `.testeiya/manual-tests/`):
 
 ```bash
 grep -rnE 'id:[[:space:]]*@S' <dir>      # suite IDs (+ which file)
@@ -146,7 +146,7 @@ npx js-yaml coverage.manual.yml | node scripts/check-coverage.mjs
 
 `npx js-yaml` parses the file (and fails loudly if the YAML is malformed, so a broken file never reaches the script). `check-coverage.mjs` then flags any key whose path is missing on disk, any key with no identifiers, and prints every `@S…` / `@T…` / tag it references. Check that list against the IDs you extracted in Step 2 — only you know which are real. Don't re-parse the markdown; use the set you already have. Never use `python`.
 
-> The keys in the coverage file are paths to source files in this repo, never `.testclaw/...` paths. The cache holds the test cases; the coverage file points at the code they cover.
+> The keys in the coverage file are paths to source files in this repo, never `.testeiya/...` paths. The cache holds the test cases; the coverage file points at the code they cover.
 
 Then show the produced YAML to the user.
 
@@ -171,7 +171,7 @@ TESTOMATIO_RUNGROUP="Regression 911" npx @testomatio/reporter run \
 
 Recommend committing `coverage.manual.yml` to the repository so CI and teammates use the same mapping.
 
-If you pulled the cases, tell the user they stay in the gitignored `.testclaw/manual-tests/`. A re-run or a follow-up question reuses them, and nothing was committed. Don't delete the cache or move it into a tracked folder.
+If you pulled the cases, tell the user they stay in the gitignored `.testeiya/manual-tests/`. A re-run or a follow-up question reuses them, and nothing was committed. Don't delete the cache or move it into a tracked folder.
 
 ### Step 7: Suggest follow-ups
 
@@ -179,8 +179,8 @@ Once the file is saved, propose any of:
 
 - Scan the source for **coverage gaps** (features without manual tests). On approval, propose new manual cases (delegate to `qa-write-test-cases`).
 - Scan for **dead tests** (manual tests whose features no longer exist in source).
-- Answer questions like "do we have manual tests for X?" from the cached cases in `.testclaw/manual-tests/`.
-- If the user wants to *edit* cases, they can edit them right in `.testclaw/manual-tests/` and push back with `sync-test-cases-with-tms` — gitignored doesn't mean read-only.
+- Answer questions like "do we have manual tests for X?" from the cached cases in `.testeiya/manual-tests/`.
+- If the user wants to *edit* cases, they can edit them right in `.testeiya/manual-tests/` and push back with `sync-test-cases-with-tms` — gitignored doesn't mean read-only.
 
 ---
 
@@ -207,7 +207,7 @@ It's the only script — everything else is `grep`, your file tool, or `npx js-y
 
 ### Recovery
 
-- **No manual tests found (cache included)** → have `sync-test-cases-with-tms` pull into `.testclaw/manual-tests/`, or ask the user for a directory the scan missed.
+- **No manual tests found (cache included)** → have `sync-test-cases-with-tms` pull into `.testeiya/manual-tests/`, or ask the user for a directory the scan missed.
 - **Markdown files with no `@S`/`@T` IDs** → ask whether to push first via `sync-test-cases-with-tms`, or skip those files.
 - **Ambiguous source layout** → ask the user which directories are application code.
 
@@ -225,7 +225,7 @@ It's the only script — everything else is `grep`, your file tool, or `npx js-y
 ```
 Use qa-manual-tests-to-code-coverage skill to build coverage.manual.yml for our manual cases
 ```
-If there are no local `.test.md` files, it pulls them into the gitignored `.testclaw/manual-tests/` and works from there.
+If there are no local `.test.md` files, it pulls them into the gitignored `.testeiya/manual-tests/` and works from there.
 
 **Cases already local:**
 ```
@@ -238,7 +238,7 @@ Use qa-manual-tests-to-code-coverage skill, output to ops/coverage.qa.yml
 ```
 
 **Full workflow (source repo):**
-1. `qa-manual-tests-to-code-coverage` runs `scan-automation-project`. No local cases, so it has `sync-test-cases-with-tms` pull into `.testclaw/manual-tests/` (gitignored) and re-runs `scan-automation-project`.
+1. `qa-manual-tests-to-code-coverage` runs `scan-automation-project`. No local cases, so it has `sync-test-cases-with-tms` pull into `.testeiya/manual-tests/` (gitignored) and re-runs `scan-automation-project`.
 2. It maps source files to suite/test/tag IDs and writes `coverage.manual.yml`. The only tracked changes are that file and one line in `.gitignore`.
 3. `npx @testomatio/reporter run --kind manual --filter "coverage:file=coverage.manual.yml,diff=main"` creates a pending run with only the affected cases.
 
@@ -248,6 +248,6 @@ Use qa-manual-tests-to-code-coverage skill, output to ops/coverage.qa.yml
 
 | Action                                 | Command                                                                                              |
 | -------------------------------------- | ---------------------------------------------------------------------------------------------------- |
-| Pull cases into the gitignored cache  | `npx check-tests pull -d .testclaw/manual-tests`                                            |
+| Pull cases into the gitignored cache  | `npx check-tests pull -d .testeiya/manual-tests`                                            |
 | Create affected manual run             | `npx @testomatio/reporter run --kind manual --filter "coverage:file=coverage.manual.yml,diff=main"`  |
 | Group runs                             | `TESTOMATIO_RUNGROUP="Regression 911" npx @testomatio/reporter run --kind manual --filter "..."`     |

--- a/skills/qa-pr-requirements-analyzer/SKILL.md
+++ b/skills/qa-pr-requirements-analyzer/SKILL.md
@@ -199,7 +199,7 @@ Stop execution if:
 | Description | File |
 |-------------|------|
 | Filled example of the output summary | [summary-example.md](./references/summary-example.md) |
-| `.testclaw/` directory convention | inherited from `project-scan` (see project-scan SKILL.md) |
+| `.testeiya/` directory convention | inherited from `project-scan` (see project-scan SKILL.md) |
 | Code-focused PR analysis (companion skill) | `../pull-request-diff-analyzer/SKILL.md` |
 | Downstream: generate test cases from requirements | `../qa-write-test-cases/SKILL.md` |
 | Downstream: sync generated cases to Testomat.io | `../sync-cases/SKILL.md` |

--- a/skills/qa-write-test-cases/SKILL.md
+++ b/skills/qa-write-test-cases/SKILL.md
@@ -320,7 +320,7 @@ Where to store test cases?
 
 - If this workspace is empty or is for manual-tests only, test cases must be generated in root
 - If this is end-to-end testing project test cases must be generated in `manual-tests` directory
-- In any other case test cases must be generated in `.testclaw/manual-tests` (ensure `.testclaw` directory exists and git ignored)
+- In any other case test cases must be generated in `.testeiya/manual-tests` (ensure `.testeiya/` directory exists and git ignored)
 
 **Proceed with this step only after user approval of checklist.**
 

--- a/skills/scan-automation-project/SKILL.md
+++ b/skills/scan-automation-project/SKILL.md
@@ -54,29 +54,30 @@ Where is the source code?
 ```
 [Waits for the user's reply.]
 
-- If user provides `Git repo` or `another folder` variant => clone or symlink it into `.testclaw/code/` (see the rule below). No-op if it's already there.
+- If user provides `Git repo` or `another folder` variant => clone or symlink it into `.testeiya/code/` (see the rule below). No-op if it's already there.
 
-#### Rule for pulled data — `.testclaw/`
+#### Rule for pulled data
 
-Detect if we are inside a git repo, skip this rule if not.
-In this case we must be strict about additional data we need to collect.
-It is highly recommended to pull all required data into `.testclaw/` by any testomatio skill.
+**When you need to pull external data** (manual test cases, app code, e2e tests from another repo) into this project:
 
-1. First, see what's already in the current folder.
-2. If you need data that isn't here — manual test cases, the application code, files for requirements, e2e tests, a repo to clone — pull it into `.testclaw/` (gitignored). **Never** pull it into current workspace folder
-3. If the data is already in the repo, use it where it is — you don't need `.testclaw/` for that.
+| This project has | Store pulled data in | Gitignored? |
+| ------------------ | ---------------------- | ----------- |
+| **Source code** (`src/` folder) or **big project** | `.testeiya/…` | **Yes** |
+| **Only test infrastructure** (e2e dirs like `tests/`, `playwright/`, `cypress/` but no `src/`) | `manual-tests/` or `e2e-tests/` | No |
+| **Empty / manual-only** | `manual-tests/` | No |
 
-| When you run inside…    | What you'd pull in…  | Goes in…                          |
-| ----------------------- | -------------------- | --------------------------------- |
-| a source-code repo      | manual test cases    | `.testclaw/manual-tests/` |
-| a manual-tests repo     | the application code | `.testclaw/code/`         |
-| (e2e tests in own repo) | the e2e tests        | `.testclaw/e2e-tests/`    |
+**Detection logic:**
+1. Has `src/` folder or is a monorepo? → Use `.testeiya/`
+2. Has e2e test dirs (`tests/`, `playwright/`, `cypress/`, `e2e/`)? → Use tracked folder (`manual-tests/`, `e2e-tests/`)
+3. Otherwise → Default to `manual-tests/`
 
-Any skill that creates `.testclaw/...` must also add `.testclaw/` to the project's `.gitignore` — but only if it is not there yet. Never add it twice.
+Any skill that creates `.testeiya/...` must also add `.testeiya/` to the project's `.gitignore` — but only if it is not there yet. Never add it twice.
 
 (The rule is about *pulled* data. Output a skill *produces* and the user wants — a `coverage.*.yml`, new `*.test.md` files — goes in the repo as normal.)
 
-On a source repo with no manual tests, `scan-automation-project` changes no tracked file: it only creates the gitignored `.testclaw/` directory and, if needed, adds one line to `.gitignore`.
+On a source repo with no manual tests, `scan-automation-project` changes no tracked file: it only creates the gitignored `.testeiya/` directory and, if needed, adds one line to `.gitignore`.
+
+**Only touch `.testeiya/` and tracked folders — never pollute repo with cache in wrong location.**
 
 ---
 
@@ -99,8 +100,8 @@ Exclude:
 - Dependencies (e.g. `node_modules/`, `vendor/`, `.venv/`).
 - Build/generated output (e.g. `dist/`, `build/`, `.next/`, `target/`).
 - Coverage, reports, caches, config, lock, and environment files.
-- Ignored paths from `.gitignore` — but **not** `.testclaw/code/`. In a manual-tests repo the app code lives there, so scan it as source even though `.testclaw/` is gitignored.
-- TestClaw internal files (e.g. `session-factory.ts`, `system-prompt.ts`).
+- Ignored paths from `.gitignore` — but **not** `.testeiya/code/`. In a manual-tests repo the app code lives there, so scan it as source even though `.testeiya/` is gitignored.
+- Testeiya internal files (e.g. `session-factory.ts`, `system-prompt.ts`).
 [**If in doubt**, prefer excluding over including non-source files.]
 
 #### 3. Detect Tech Stack
@@ -177,7 +178,7 @@ For each detected framework:
 
 ### Manual Tests
 
-Find all `.test.md` files and parse test titles. `find .` also looks inside `.testclaw/manual-tests/`, so a re-run after a pull finds the cached cases instead of reporting "no manual tests":
+Find all `.test.md` files and parse test titles. `find .` also looks inside `.testeiya/manual-tests/`, so a re-run after a pull finds the cached cases instead of reporting "no manual tests":
 
 ```bash
 find . -name "*.test.md" -exec awk '
@@ -193,7 +194,7 @@ find . -name "*.test.md" -exec awk '
 ' {} +
 ```
 
-If the only `.test.md` files are under `.testclaw/manual-tests/`, say so in the inventory: they came from Testomat.io, not from this repo.
+If the only `.test.md` files are under `.testeiya/manual-tests/`, say so in the inventory: they came from Testomat.io, not from this repo.
 
 ---
 

--- a/skills/sync-test-cases-with-tms/SKILL.md
+++ b/skills/sync-test-cases-with-tms/SKILL.md
@@ -76,14 +76,14 @@ Download/Retrieves test scenarios from Testomat.io and saves them as Markdown fi
 - Refactor test cases offline.
 - Export only some specific suites by id.
 
-**Where to pull:** into the gitignored cache `.testclaw/manual-tests/`, and add `.testclaw/` to the project `.gitignore` if it is not there yet. Pulled cases must never land in a tracked folder (`manual-tests/`, etc.) — that pollutes the repo. You can still edit them there and push back; being gitignored doesn't stop that. (If the repo *already* keeps its `*.test.md` files in a tracked folder, you don't need to pull at all — work with them where they are, or pass `-d <that folder>` for an in-place refresh.) This matches `scan-automation-project`, which pulls the *code* into `.testclaw/code/` when it runs inside a manual-tests repo.
+**Where to pull:** into the gitignored cache `.testeiya/manual-tests/`, and add `.testeiya/` to the project `.gitignore` if it is not there yet. Pulled cases must never land in a tracked folder (`manual-tests/`, etc.) — that pollutes the repo. You can still edit them there and push back; being gitignored doesn't stop that. (If the repo *already* keeps its `*.test.md` files in a tracked folder, you don't need to pull at all — work with them where they are, or pass `-d <that folder>` for an in-place refresh.) This matches `scan-automation-project`, which pulls the *code* into `.testeiya/code/` when it runs inside a manual-tests repo.
 
 **Pre-Pull:**
 
-- If `testDir` is specified pull tests into it. Otherwise:
-- If this workspace is empty or is for manual-tests only, test must be pulled to root
-- If this is end-to-end testing project test cases must be generated in `manual-tests` directory
-- In any other case test cases must be pulled to `.testclaw/manual-tests` (ensure `.testclaw` directory exists and git ignored)
+- If `testDir` input is provided or user specifies `-d <path>` in command, use that path instead. Otherwise:
+  - If this workspace is empty or is for manual-tests only, test must be pulled to root
+  - If this is end-to-end testing project test cases must be generated in `manual-tests` directory
+  - In any other case test cases must be pulled to `.testeiya/manual-tests` (ensure `.testeiya/` directory exists and git ignored)
 
 **Command:**
 ```bash
@@ -101,8 +101,8 @@ Optional variant - **pull by specific suite-ids**
 
 **Pull Examples:**
 ```bash
-# Default — pull into the gitignored cache
-npx check-tests pull -d .testclaw/manual-tests
+# Auto-detected location
+npx check-tests pull -d
 
 # Repo that already keeps its test cases tracked — refresh them in place
 npx check-tests pull -d manual-tests
@@ -126,8 +126,12 @@ Uploads/Imports local Markdown tests into Testomat.io:
 
 **Pre-Push File Filtering**
 
-If directory contains manual test cases + something else, move test cases into `.testclaw/manual-tests`
+Before uploading, scan the project and identify only manual test cases:
+- Files matching `*.test.md` (ignore all other Markdown files (such as `README.md`, `CHANGELOG.md`, and project documentation)).
+- Markdown files containing valid `<!-- test ... -->` blocks.
 
+If the project contains manual test cases alongside other files, copy or move the identified test case files into the cache folder: 
+- `.testeiya/manual-tests/`
 
 **Pre-Push Validation:**
 1. Ensure at least one test `*.test.md` file exists.
@@ -164,19 +168,16 @@ npx check-tests push --files "**/*.test.md"
 # Default glob (**/*.test.md) under -d
 npx check-tests push
 
-# Specify directory with manual test cases
-npx check-tests push -d .testclaw/manual-tests
-
-# Specify directory with manual test cases and specific files
-npx check-tests push -d .testclaw/manual-tests --files new_tests.md
+# Testeiya cache folder with manual test cases
+npx check-tests push -d .testeiya/manual-tests
 ```
 
 **Important constraints:**
 - Only use options explicitly documented in this skill or in the "Testomat.io CLI Documentation" ref file.
 - If you are unsure about available CLI options, run `npx check-tests --help` and use only options listed there.
 - Do **not** use an option unless it is mentioned in the documentation or in the `--help` option (e.g., `--pattern`, `--forces`).
-- Ensure you use -d when `.testclaw` or `manual-tests` directories exist. 
-- Ensure you push only the test cases directory (e.g `.testclaw/manual-tests` not `.testclaw`).
+- Ensure you use -d when `.testeiya` or `manual-tests` directories exist. 
+- Ensure you push only the test cases directory (e.g `.testeiya/manual-tests` not `.testeiya/`).
 
 **More examples** you can find in "Push" section [Testomat.io CLI Documentation](./references/TESTOMATIO_CLI.md)
 
@@ -189,7 +190,7 @@ After completing sync operations, output a short log-style summary:
 ```
 Sync Complete:
 - Action: pull/push
-- Directory: .testclaw/manual-tests
+- Directory:  <auto-detected path>
 - Tests synced: 15
 - Status: Success
 ```
@@ -227,7 +228,7 @@ Stop execution if:
 
 ## Examples
 
-**Pull tests** (lands in the gitignored `.testclaw/manual-tests/`):
+**Pull tests:**
 ```
 Use sync-test-cases-with-tms skill to pull tests from Testomat.io
 ```


### PR DESCRIPTION
Based on the description from the Testita - https://github.com/testomatio/testeiya-app
The default cache folder name was renamed from `.testclaw/` to `.testeiya/`to sync with local naming