### PR TITLE
automate-manual-test-cases: gate "done" on actual test execution

### DIFF
--- a/skills/automate-manual-test-cases/SKILL.md
+++ b/skills/automate-manual-test-cases/SKILL.md
@@ -28,8 +28,10 @@ Complete ALL items in order:
 1. [ ] **Analyze Project Architecture** => Detect framework (1.1), identify excluded paths (1.2), find reusable components (1.3).
 2. [ ] **Understand Manual Test** => Normalize input (2.0), handle ambiguous steps (2.1), detect inconsistencies (2.2).
 3. [ ] **Write Test Code** => Implement using existing POM/patterns (3.1-3.2), add assertions (3.3), output code (3.4).
-4. [ ] **Verify & Heal** => Execute test (4.1), heal if fails - locators → timing → assertions → flow (4.2), max 3 attempts.
+4. [ ] **Verify & Heal** => Check run prerequisites (4.0), execute test (4.1), heal if fails - locators → timing → assertions → flow (4.2), max 3 attempts.
 5. [ ] **Finalization** => Ensure structure compliance (5.1), manage test data & fixtures (5.2), run related tests and output summary (5.3 & 5.4).
+
+> 🚦 **Completion gate:** never report the task **done** — and never present a "generated" or "coverage" summary as complete — unless **every generated test was actually executed and passed**. Code that only compiles or type-checks is **not** done. If a test could not be run (missing env var, credentials, service, or config), the status is **⛔ BLOCKED**, not done: say so at the **top** of your reply, name exactly what is missing, and do not imply the tests work.
 
 ### Progress
 * STEP: 1/5 (Analyze Project Architecture)
@@ -254,6 +256,16 @@ Avoid:
 
 Verify the generated test by executing it and fixing issues if needed.
 
+> ❗ **Execution is mandatory, not optional.** You have not finished this skill until the generated test has actually run. Do not stop at "code written" or "type-checks pass".
+
+#### 4.0 Check Run Prerequisites (before executing)
+
+Confirm the test can actually start in this environment — do this **early** (ideally right after Step 1) so blockers surface before you write a full suite, not after.
+
+- Read `.env.example` / `.env`, `codecept.conf.*` / `playwright.config.*`, and any global setup for the **required env vars, tokens, and credentials**.
+- Confirm the base URL / service the tests hit is reachable.
+- If a required value is missing, that is a **⛔ BLOCKED** prerequisite (see Error Handling) — surface it now with the exact variable name; do not defer it to a footnote.
+
 #### 4.1 Execute Test
 
 **Standard execution:**
@@ -263,6 +275,7 @@ Verify the generated test by executing it and fixing issues if needed.
 **Result:**
 - If test **passes** → proceed to Step 5  
 - If test **fails** → start healing (4.2)  
+- If the framework **cannot start** (missing env var, failed module include, unreachable service) → this is **⛔ BLOCKED**, not a test failure and not done. Do not heal locators/timing — stop and report the blocker (see Error Handling).
 
 > ⚠️ **Do NOT run all tests**. Limit execution to the generated test to avoid excessive logs and noise.
 
@@ -364,6 +377,12 @@ Output structured summary (see [Final Summary Template](./references/FINAL_SUMMA
 
 * **Test Execution Problems**
   - If no option to execute test after 3 attempt => Stop and catch the error.
+
+* **Cannot run at all (environment / prerequisites)**
+  - A missing env var / token / credential, a framework bootstrap failure, or an unreachable service means the test **never executed**.
+  - Report status **⛔ BLOCKED** at the **top** of the summary — not as a footnote after a "done" table.
+  - State the **exact** missing prerequisite (e.g. the env var name) and how to provide it.
+  - Do **not** claim the tests pass, are "implemented", or present completed coverage — they are unverified until they run.
 
 ---
 

--- a/skills/automate-manual-test-cases/references/FINAL_SUMMARY_TEMPLATE.md
+++ b/skills/automate-manual-test-cases/references/FINAL_SUMMARY_TEMPLATE.md
@@ -2,10 +2,14 @@
 
 Use this template after completing the conversion process:
 
+> 🚦 **`Status: ✅ Done` is allowed only when `Executed == Tests generated` and every one passed.** If any test did not run — including framework-level blockers like a missing env var — use **`⛔ Blocked`** (nothing executed) or **`⚠️ Needs review`** (some ran, some didn't), put the reason at the top, and do **not** mark generated files ✅.
+
 ```
 **Summary:**
+- Status: [✅ Done | ⚠️ Needs review | ⛔ Blocked]
 - Framework: [Playwright/CodeceptJS/Cypress]
 - Tests generated: [N]
+- Executed: [N]
 - Passed: [N]
 - Needs review: [N]
 
@@ -25,8 +29,10 @@ Use this template after completing the conversion process:
 
 ```
 **Summary:**
+- Status: ⚠️ Needs review
 - Framework: Playwright
 - Tests generated: 10
+- Executed: 10
 - Passed: 8
 - Needs review: 2
 
@@ -43,4 +49,27 @@ Use this template after completing the conversion process:
 **Next steps:**
 - Review ⚠️ tests
 - Run full suite if needed
+```
+
+## Example Blocked Summary
+
+When the tests could not run at all, lead with the blocker — never present unrun tests as done.
+
+```
+**⛔ Blocked — tests were written but NOT executed**
+
+Cannot run: `npx codeceptjs run` stops at bootstrap because env var `BETA_MAIN_USER_GENERAL_TOKEN` is missing.
+
+**Summary:**
+- Status: ⛔ Blocked
+- Framework: CodeceptJS
+- Tests generated: 4
+- Executed: 0
+- Passed: 0
+
+**Generated Files (unverified — did not run):**
+- tests/defects/defectsBoard.test.ts ⛔
+
+**To unblock:**
+- Set `BETA_MAIN_USER_GENERAL_TOKEN` in `.env`, then re-run the test.
 ```


### PR DESCRIPTION
## Problem

The `automate-manual-test-cases` skill listed "Execute test" as a step but never made a **passing run a precondition for reporting completion**. In a real Testeiya session the agent:

1. Wrote a CodeceptJS suite for the Defects Board,
2. Ran `prettier` + `tsc --noEmit` (both passed),
3. Ran `npx codeceptjs run …` — which **stopped at framework bootstrap** because env var `BETA_MAIN_USER_GENERAL_TOKEN` was missing (the `testomatApi` include needs it),
4. …then still presented a **"Implemented Defects Board automation" + coverage table** that reads as *done*.

The tests **never executed**, but the summary looked complete. The user could not tell, and (understandably) exploded: *"did you execute tests?"* → *"WHAT THE FUCK??? HOW DID YOU WRITE THEM THEN??"*

## Fix

Make actual execution a hard gate on "done":

- **Completion gate** (checklist + Step 4): never report done / never present a "generated" or "coverage" summary as complete unless **every generated test actually executed and passed**. Compiling or type-checking is *not* done.
- **Step 4.0 "Check Run Prerequisites"**: read `.env(.example)` / config for required env vars, tokens, and credentials **early** (right after project analysis) so a run blocker surfaces *before* a full suite is written, not after.
- **Blocker vs. failure**: a framework bootstrap / environment problem (missing env var, failed module include, unreachable service) is **⛔ BLOCKED**, not a test failure — do not heal locators/timing, stop and report it.
- **Error Handling**: report BLOCKED at the **top** with the exact missing prerequisite; never claim unrun tests pass or are "implemented".
- **FINAL_SUMMARY_TEMPLATE**: add a `Status` field (`✅ Done | ⚠️ Needs review | ⛔ Blocked`) and an `Executed` count — `✅ Done` only when `Executed == Tests generated` and all passed. Added a Blocked example modeled on the real failure.

## Scope

Docs-only (skill markdown). No behavior change beyond the model's own reporting discipline.

🤖 Generated with [Claude Code](https://claude.com/claude-code)