### PR TITLE
Make coverage mapping proactive, inventory-complete, and domain-planned

### DIFF
--- a/skills/qa-test-code-coverage/SKILL.md
+++ b/skills/qa-test-code-coverage/SKILL.md
@@ -22,6 +22,7 @@ Analyze the project's tests — manual markdown cases and automated e2e tests �
 - Never pull or clone tests into a tracked folder — only into the gitignored `.testeiya/`.
 - **Everything in the coverage file must come from this project:** file keys from its source tree, identifiers from the Step 2 inventory. Never copy a path or ID from this skill's docs — they are placeholders.
 - **No ad-hoc scripts, no parsers, never Python.** File reads and `grep` only; the single exception is the bundled checker (Step 5); beyond that a one-line `node -e '…'` is the limit.
+- **Be proactive — never stop at a representative sample.** A few entries per domain is a failed run. Keep mapping without asking permission to continue until the completion criterion in Step 4 is met.
 - Stop if you cannot write the output file, or no tests are found and the user declines every option in Step 1.
 
 ## Workflow
@@ -77,14 +78,19 @@ Missing IDs mean the tests were never synced with Testomat.io — the reporter c
 
 ### Step 4: Map source files to tests
 
-Split the mapping by codebase size (complexity from Step 1):
+**The Step 2 inventory is the work list. The map is complete only when every suite in it is either present in the coverage file or recorded as unmapped with a reason.** Run two passes — always both:
 
-- `small` / `medium` — map directly in this session.
-- `large` / `very-large`, or many top-level source folders — spawn subagents in parallel, one per source folder. Give each subagent:
-  - its folder path and the skip rules from Step 3;
+- Code → tests: walk the source tree from Step 3; for each file or subtree, add the identifiers of the tests that check it.
+- Tests → code: walk the inventory; for every suite still absent from the map, find the source it exercises and add it — or record why it cannot be mapped (feature has no code here, external system, needs user input).
+
+Scale the passes to the project — codebase size and suite count from Step 1:
+
+- Small codebase and few suites — run both passes in this session.
+- Large codebase or dozens of suites — spawn subagents in parallel: one per source folder for the code→tests pass, then one per batch of still-unmapped suites for the tests→code pass. Give each subagent:
+  - its slice — a folder path, or a batch of suites;
   - the full test inventory from Step 2 — subagents must not re-extract it;
   - the mapping rules below and the [Coverage File Format](./references/COVERAGE_FILE_FORMAT.md);
-  - the instruction to return a YAML fragment for files inside its folder only.
+  - the instruction to return a YAML fragment for its slice only.
 - Merge the fragments into one map, drop duplicate keys and empty entries. Only the main session writes the file (Step 5).
 
 For each candidate source file, pick the identifier that keeps selecting the right tests as the test suite grows:
@@ -108,16 +114,24 @@ YAML grammar: [Coverage File Format](./references/COVERAGE_FILE_FORMAT.md).
 
 - Write the YAML to the output path, keeping the `#` comments.
 - Keys are paths to source files in this repo — never `.testeiya/...` paths.
-- Check it from the project root:
+- Check it with the bundled checker. It ships in this skill's `scripts/` directory (next to this SKILL.md), not in the project — resolve its path from the skill location:
 
 ```bash
-npx js-yaml coverage.tests.yml | node scripts/check-coverage.mjs
+npx js-yaml coverage.tests.yml | node <path-to-this-skill>/scripts/check-coverage.mjs
 ```
 
 - The checker flags keys missing on disk and empty entries, and prints every identifier referenced — cross-check them against the Step 2 inventory; only you know which are real.
-- Show the produced YAML to the user.
+- Reconcile the other direction too: every suite in the inventory must appear in the file or in the unmapped list. Anything missing from both means the tests→code pass is not finished — go back to Step 4.
 
-### Step 6: Show next steps
+### Step 6: Report coverage completeness
+
+Show the user:
+
+- Suites mapped vs. total suites in the inventory; same for tests and tags where meaningful.
+- Every unmapped suite with its reason.
+- The produced YAML (or its path and entry count when large).
+
+### Step 7: Show next steps
 
 Tell the user how to use the file with `@testomatio/reporter`:
 
@@ -137,7 +151,7 @@ npx @testomatio/reporter run --kind manual \
 - In CI, diff against the base branch — `diff=origin/main` — and checkout with `fetch-depth: 0`.
 - Pulled or cloned tests stay in the gitignored `.testeiya/` cache for re-runs — don't delete it or move it into a tracked folder.
 
-### Step 7: Suggest follow-ups
+### Step 8: Suggest follow-ups
 
 - Coverage gaps — source features no test maps to. On approval, propose new cases (delegate to `qa-write-test-cases`).
 - Dead tests — tests whose features no longer exist in source.

--- a/skills/qa-test-code-coverage/SKILL.md
+++ b/skills/qa-test-code-coverage/SKILL.md
@@ -69,25 +69,32 @@ Missing IDs mean the tests were never synced with Testomat.io — the reporter c
 - ❓ Manual files without IDs: ask whether to push them first via `sync-test-cases-with-tms`, or skip those files.
 - Automated tests without IDs in most files: stop and instruct the user to run `npx check-tests@latest <Framework> "<glob>" --update-ids` first (per-framework commands: [E2E Frameworks](./references/E2E_FRAMEWORKS.md)).
 
-### Step 3: Explore the codebase
+### Step 3: Plan the coverage map by domain
 
-- Find the business code that implements the behaviors the tests check — controllers, models, services, components, pages, routes.
-- Skip test code, manual test directories, dependency/build/vendor folders, framework configs, lock files.
+**Do not crawl the codebase file by file.** Identify the application's domain areas first; Step 4 then maps area by area.
+
+- Derive the areas from both sides:
+  - the suite tree from Step 2 — the suite hierarchy is the QA team's own map of the product;
+  - the source structure — modules, routes, services, entry points.
+- Pair each area with the suites that test it and the source folders that implement it.
+- Order the areas by criticality, most critical first: payments/billing, auth and access control, data integrity, core business flows — then supporting features, then peripheral UI. Suite size is a signal: what QA tests heavily, they consider critical.
+- Show the ordered plan to the user before mapping.
+- Business code only: skip test code, manual test directories, dependency/build/vendor folders, framework configs, lock files.
 - **Templates and views are mappable source** (`.vue`, `.erb`, `.blade.php`, …) — tests check the rendered UI, so map them like code.
-- ❓ If the structure is ambiguous, ask the user which directories to focus on or exclude.
+- ❓ If areas or their priority are unclear, ask the user.
 
 ### Step 4: Map source files to tests
 
-**The Step 2 inventory is the work list. The map is complete only when every suite in it is either present in the coverage file or recorded as unmapped with a reason.** Run two passes — always both:
+**The Step 2 inventory is the work list. The map is complete only when every suite in it is either present in the coverage file or recorded as unmapped with a reason.** Work through the areas in Step 3's order — most critical first, so even an interrupted run covers what matters most. Run two passes — always both:
 
-- Code → tests: walk the source tree from Step 3; for each file or subtree, add the identifiers of the tests that check it.
+- Code → tests: for each area, map its source files and subtrees to the identifiers of the tests that check them.
 - Tests → code: walk the inventory; for every suite still absent from the map, find the source it exercises and add it — or record why it cannot be mapped (feature has no code here, external system, needs user input).
 
 Scale the passes to the project — codebase size and suite count from Step 1:
 
 - Small codebase and few suites — run both passes in this session.
-- Large codebase or dozens of suites — spawn subagents in parallel: one per source folder for the code→tests pass, then one per batch of still-unmapped suites for the tests→code pass. Give each subagent:
-  - its slice — a folder path, or a batch of suites;
+- Large codebase or dozens of suites — spawn subagents in parallel: one per domain area for the code→tests pass, then one per batch of still-unmapped suites for the tests→code pass. Give each subagent:
+  - its slice — one area (its suites and source folders), or a batch of suites;
   - the full test inventory from Step 2 — subagents must not re-extract it;
   - the mapping rules below and the [Coverage File Format](./references/COVERAGE_FILE_FORMAT.md);
   - the instruction to return a YAML fragment for its slice only.

--- a/skills/qa-test-code-coverage/references/COVERAGE_FILE_FORMAT.md
+++ b/skills/qa-test-code-coverage/references/COVERAGE_FILE_FORMAT.md
@@ -118,13 +118,13 @@ jobs:
 
 ## Checking the coverage file
 
-One command, run from the project root — no parser of your own:
+One command — no parser of your own. Run it with the project root as working directory (file keys resolve against it), but the checker itself lives in the skill's `scripts/` directory, not in the project:
 
 ```bash
-npx js-yaml coverage.tests.yml | node scripts/check-coverage.mjs
+npx js-yaml coverage.tests.yml | node <path-to-this-skill>/scripts/check-coverage.mjs
 ```
 
-`npx js-yaml` parses the YAML (it fails loudly on a malformed file, so a broken one never reaches the script). `scripts/check-coverage.mjs` (~25 lines, zero deps; ships with `qa-test-code-coverage`) reads that parsed map on stdin, flags any key whose path is missing on disk, flags any key with no identifiers, lists every `@S…` / `@T…` / tag the file references, and exits non-zero on a problem.
+`npx js-yaml` parses the YAML (it fails loudly on a malformed file, so a broken one never reaches the script). `check-coverage.mjs` (~25 lines, zero deps) reads that parsed map on stdin, flags any key whose path is missing on disk, flags any key with no identifiers, lists every `@S…` / `@T…` / tag the file references, and exits non-zero on a problem.
 
 The script can't tell which identifiers are real — check the listed ones against the set you extracted earlier in the workflow. Don't re-parse the test set, don't write your own YAML parser, and never use `python`.
 


### PR DESCRIPTION
## Summary

Follow-up to #155 (replaces #156, which was based on the pre-squash branch), driven by a real run against a project with **2163 manual + 200 automated tests**: the agent produced 50 file keys covering ~25 suites in 3 minutes — it sampled 9 showcase domains file-by-file and stopped, because nothing in the skill defined *done*. The same run also failed validation because the skill pointed at `scripts/check-coverage.mjs` in the project root, where the script does not exist.

Changes to `qa-test-code-coverage`:

- **New Step 3 — plan by domain, most critical first.** Do not crawl file by file: derive domain areas from the suite hierarchy (the QA team's own product map) crossed with the source structure, pair each area with its suites and source folders, order by criticality (payments/billing, auth, data integrity, core flows → supporting → peripheral; suite size is a criticality signal), and show the plan before mapping.
- **The Step 2 inventory is the work list, with a hard completion criterion:** the map is complete only when every suite is in the coverage file or recorded as unmapped with a reason. Step 5 reconciles both directions; a suite missing from both sends the agent back to mapping.
- **Two mandatory passes:** code→tests area by area in criticality order (an interrupted run still covers what matters most), then tests→code for every suite still absent — the pass that pulls the full domain into the map.
- **Proactive constraint:** never stop at a representative sample, never ask permission to continue; a few entries per domain is a failed run.
- **Fan-out scales with suite count, not just codebase size** — subagent slices are domain areas for the code→tests pass and suite batches for the tests→code pass.
- **New Step 6 — report completeness:** suites mapped vs. total plus every unmapped suite with its reason, so gaps are visible instead of silent.
- **Checker path fixed:** `check-coverage.mjs` ships in the skill's `scripts/` directory — the command now resolves it from the skill location while running with the project root as working directory (also fixed in `COVERAGE_FILE_FORMAT.md`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)