### PR TITLE
MCP document label/custom-field linking & scoped labels

### DIFF
--- a/skills/testomatio-mcp/SKILL.md
+++ b/skills/testomatio-mcp/SKILL.md
@@ -26,7 +26,7 @@ Set up access to Testomat.io via MCP and run QA analysis workflows: run analysis
 - Run: `runs_list`, `runs_get`, `runs_search`
 - Testrun (results within a run): `testruns_list`, `testruns_get`
 - Suite: `suites_list`, `suites_get`, `suites_search`
-- Label: `labels_list`, `labels_get`
+- Label: `labels_list`, `labels_get`, `labels_create`, `labels_update`, `labels_delete`. Labels may be scoped (`key:value`). Attach or swap them on entities via the `link` parameter — [MCP Setup Reference](./references/MCP_SETUP.md).
 - Tag: `tags_list`, `tags_get`, `tags_search`
 
 **CRUD tools (create, update, delete) exist for all entities. Use them only when explicitly needed for targeted updates.**
@@ -169,6 +169,16 @@ Goal: turn recurring failures into trackable defects.
    - if a Jira MCP is available, offer to create the ticket via the Jira skill
 3. After defect creation, call `tests_issues_link` for each affected test to link it to the defect.
 
+### Workflow 5: Update Labels & Tags on Tests
+
+Goal: set, change, or remove labels and tags on tests — for example, update a status label that drives a dashboard chart.
+
+1. Call `labels_list` (or `project_info`) to read the exact label values that exist in the project, including the full `key:value` form of scoped labels. Do not guess label strings.
+2. Optionally find the tests to update with `tests_list` + TQL: `label == 'regression:yes'`.
+3. Update with `tests_update` (or `tests_create`) using the `link` array — one `{ action, type, value }` entry per change. To change a value (e.g. `regression:no` → `regression:yes`), send a `remove` and an `add` in the same call. The same shape works for `tag`, `custom_field`, `milestone`, `issue`, and `jira`.
+
+Link format and a full swap example: [MCP Setup Reference](./references/MCP_SETUP.md).
+
 ## Quick Commands
 
 | Action              | MCP Tool        | Key Parameters |
@@ -179,4 +189,7 @@ Goal: turn recurring failures into trackable defects.
 | Get test details    | `tests_get`     | `test_id` |
 | Get plan details    | `plans_get`     | `plan_id` |
 | Link issue to test  | `tests_issues_link` | `test_id`, `url` or `jira_id` |
+| List labels         | `labels_list`   | `page`, `per_page` |
+| Set / swap label on test | `tests_update` | `test_id`, `link` |
+| Find tests by label | `tests_list`    | `tql: label == '...'` |
 | Check server status | `system_ping`   | none |

--- a/skills/testomatio-mcp/references/MCP_SETUP.md
+++ b/skills/testomatio-mcp/references/MCP_SETUP.md
@@ -140,6 +140,7 @@ Supported operators: `==`, `!=`, `>`, `<`, `>=`, `<=`, `in [...]`, `%` (contains
 - `state == 'automated'`
 - `suite % 'Checkout'`
 - `tag IN ['@smoke', '@regression']`
+- `label == 'regression:yes'` (scoped / `key:value` label)
 
 **Runs:**
 - `title % 'Manual tests'`
@@ -166,4 +167,11 @@ Or in MCP client config, pass `NODE_OPTIONS` in the server `env` block.
 - **Run status transitions** use `runs_update` with `status_event` values: `finish`, `finish_manual`, `launch`, `rerun`, `scheduled`, `terminate`.
 - **Search** for tests and runs uses `tql` as the single filter input; no dedicated `/search` endpoints.
 - **Issue linking** supports scoped helpers: `tests_issues_link/unlink`, `suites_issues_link/unlink`, `runs_issues_link/unlink`.
+- **Linking labels, tags, milestones, issues** to an entity (test, suite, run, plan, step, snippet) uses the `link` array on `*_create` / `*_update`. Each entry is `{ "action": "add"|"remove", "type": "label"|"custom_field"|"tag"|"milestone"|"issue"|"jira", "value": "<title or Key:Value>" }` (suites also accept `requirement`). `label` and `custom_field` are interchangeable on the backend; pass the full `Key:Value` string as `value` for custom fields. Swap a value in one call by combining `remove` and `add`:
+  ```json
+  "link": [
+    { "action": "remove", "type": "label", "value": "regression:no" },
+    { "action": "add", "type": "label", "value": "regression:yes" }
+  ]
+  ```
 - **API Sessions** are automatically managed by the MCP server: a session starts before the first mutating request and stops when the server shuts down.


### PR DESCRIPTION
## Summary
     
Adds guidance for working with labels and custom fields (including scoped `key:value` labels that drive custom dashboards): agents now get a discover -> find -> update workflow using `labels_list`, TQL `label ==`, and the `link` parameter on `tests_update`, so they can set and swap label values on tests instead of guessing.