### PR TITLE
Single-stage PR testing: create the run after the deploy

### DIFF
--- a/skills/run-tests-with-testomatio-reporter/SKILL.md
+++ b/skills/run-tests-with-testomatio-reporter/SKILL.md
@@ -30,6 +30,7 @@ metadata:
 | manual    | `--kind manual` | manual cases only — pending for testers, complete without any launch                            |
 | mixed     | `--kind mixed`  | manual + automated in one run — testers work it while the automated part is launched separately |
 | automated | *(no flag)*     | automated tests only                                                                            |
+| detect    | `--kind detect` | Testomat.io picks the kind from the tests the run was scoped to — prefer it on filtered runs    |
 
 A run created with `start` executes nothing: manual cases are pending immediately; an automated part stays scheduled until launched. `--format id` prints only the run id to stdout (banner and logs go to stderr), so capture is clean:
 

--- a/skills/setup-change-aware-pr-testing/SKILL.md
+++ b/skills/setup-change-aware-pr-testing/SKILL.md
@@ -1,49 +1,50 @@
 ---
 name: setup-change-aware-pr-testing
-description: Set up CI so every pull request gets a Testomat.io run scoped to the code it changes. When a PR opens, testers get that run immediately; the affected automated tests launch after a preview deploy or on merge. Use when the user wants to integrate Testomat.io runs into a CI pipeline, create test runs per pull request, or set up change-aware testing that triggers affected tests from CI events.
+description: Set up CI so every pull request gets a Testomat.io run scoped to the code it changes. One job runs after the deploy — it creates the run and launches the affected tests into it. Use when the user wants to integrate Testomat.io runs into a CI pipeline, create test runs per pull request, or set up change-aware testing that triggers affected tests from CI events.
 license: MIT
 metadata:
   author: Testomat.io
-  version: 4.0.0
+  version: 5.0.0
 ---
 
 # Setup Change-Aware PR Testing
 
 I set up a project's CI for change-aware PR testing. The knowledge here is the flow model and the decisions to confirm with the user; what gets wired depends on the project's tests:
 
-- manual — testers get a run to start on Testomat.io the moment the PR opens; nothing to execute.
+- manual — testers get a run to work through against the deployed change; nothing to execute.
 - automated — an execution mode must be chosen: inline in the pipeline, a Testomat.io CI profile, or another workflow/repo.
 - mixed — both, sharing one run per PR.
 
 Two skills carry the mechanics — read both before wiring:
 
-- `run-tests-with-testomatio-reporter` — every reporter command and env var the jobs execute.
+- `run-tests-with-testomatio-reporter` — every reporter command and env var the job executes.
 - `setup-ci-automation` — CI investigation, workflow-authoring rules, diagram conventions, secrets, PR delivery.
 
-> **GOAL: a working pipeline committed to the project's own CI system.** That CI configuration is the one and only finished result. I run locally to author it — I am never part of CI. Do not execute reporter commands while authoring; the one exception is the final battle-test (Step 6), on a PR the user picked.
+> **GOAL: a working pipeline committed to the project's own CI system.** That CI configuration is the one and only finished result. I run locally to author it — I am never part of CI. Do not execute reporter commands while authoring; the only exceptions are the Testomat.io CI profile check (Step 2) and the final battle-test (Step 6).
+
+The minimal setup is **one job, gated on the deploy**: it creates the run and launches the tests together. Propose that. Splitting creation and launch across two jobs is possible when the user needs it — the run id is then carried between them.
 
 ## Possible flows
 
 When the environment renders Mermaid, post this diagram as a chat message before the first question — never open with a question; it frames everything that follows. When questions go through a form or tool, the diagram must already be on screen in an earlier message.
 
-Never post a diagram bare — follow it immediately with one short paragraph explaining it: this is the general schema of PR testing, for the user to examine before anything is implemented; a run is created when a PR opens, and the user will now choose which types of tests execute (manual, automated, or both) and how the automated ones run — inline in the pipeline, through a Testomat.io CI profile, or by dispatching another repo — and when they launch (preview deploy or merge).
+Never post a diagram bare — follow it immediately with one short paragraph explaining it: this is the general schema of PR testing, for the user to examine before anything is implemented; a run is created once the change is deployed, and the user will now choose which deploys trigger it — a per-PR preview deploy, the post-merge deploy, or both — which types of tests execute (manual, automated, or both), and how the automated ones run — inline in the pipeline, through a Testomat.io CI profile, or by dispatching another repo.
 
 ```mermaid
 flowchart LR
-    PR([PR opened]) --> RUN[Create a run scoped<br/>to the PR changes]
+    DEP([Preview or post-merge<br/>deploy succeeds]) --> WHICH{PR behind<br/>this commit?}
+    WHICH -->|none| SKIP([Nothing to test])
+    WHICH -->|found| RUN[Create a run scoped<br/>to the deployed changes]
     RUN -->|manual / mixed| TESTERS[Testers execute manual cases<br/>on Testomat.io]
-    RUN -->|automated / mixed| SCHED[Schedule automated tests —<br/>nothing runs yet]
-    SCHED --> TRIG{When to launch?}
-    TRIG -->|preview deployed| MODE{How to execute?}
-    TRIG -->|PR merged| MODE
+    RUN -->|automated / mixed| MODE{How to execute?}
     MODE -->|via a Testomat.io CI profile| RES
     MODE -->|inline in this pipeline| RES
     MODE -->|by dispatching another repo| RES
-    RES[Run the affected automated tests —<br/>results land in the PR run]
+    RES[Run the affected automated tests —<br/>results land in the same run]
 ```
 
 - Manual-only project → only the top branch: the run is complete at creation, testers execute it on Testomat.io, nothing launches.
-- Automated-only project → only the bottom branch: the scheduled run launches on a trigger through the chosen mode.
+- Automated-only project → only the bottom branch: the run is created and launched in one job.
 - Mixed project → both branches share one run per PR.
 
 ## The coverage map drives everything
@@ -52,20 +53,21 @@ A coverage map maps source files/globs to test identifiers; the reporter filters
 
 ## Critical Constraints
 
-- **Never execute the reporter while authoring — the deliverable is committed CI config.** Sole exception: the user-approved battle-test (Step 6).
-- **Battle-test executes tests only for an already-merged PR**; an open PR only gets a run created.
+- **Never execute the reporter while authoring — the deliverable is committed CI config.** Two approved exceptions: the Testomat.io CI profile check (Step 2) and the battle-test (Step 6).
 - **Only touch CI config files** — never source or test files.
 - Diagrams gate the dialogue: flows diagram before the first question, selected-flow diagram approved before wiring (Step 3).
 - Discovery first — delegate to `scan-automation-project` before writing anything.
-- Never guess a Testomat.io CI profile name — pick from a list (Testomat.io MCP) confirmed by the user, or ask.
+- Never guess a Testomat.io CI profile name — pick from a list (Testomat.io MCP) confirmed by the user, or ask. Never wire one that has not been proven to launch.
 - Say "Testomat.io CI profile" in full, never bare "profile"; every question option explains itself in plain words.
 - Avoid presenting the project's full test inventory as the run scope; never print full test lists.
 - No coverage map → no pipeline; delegate map creation to `qa-test-code-coverage`.
-- The PR-open job creates the run and executes nothing.
-- A launch targeting a deployed environment waits for that deployment to finish — gate on the deploy-finished signal, never on the push or the merge event alone.
-- The run id persisted at creation is the only link between phases — every launch targets it; never wire shared-run title matching.
+- Propose one job gated on the deploy job succeeding; split creation and launch across jobs only if the user needs it, carrying the run id with the CI's value passing.
+- Preview deploys and post-merge deploys are equally valid triggers — the same job shape serves both; wire it to each deploy the project has.
+- A deployed commit with no PR behind it creates nothing.
+- `--kind detect` lets Testomat.io resolve the kind from what the run was scoped to — never hardcode `mixed`.
+- The job never fails the deploy pipeline.
 - PR comments come from the reporter's own pipes — never script a PR-comment API call.
-- The run title is the PR's own title, carried verbatim from the CI's PR-title variable, with the PR number in front. Never append words of your own — no "selective tests", no "affected tests", no framework or scope labels.
+- The run title is the PR's own title, carried verbatim from the resolved PR, with the PR number in front. Never append words of your own — no "selective tests", no "affected tests", no framework or scope labels.
 - Every run gets that title and a rungroup.
 
 ## Workflow
@@ -74,7 +76,7 @@ A coverage map maps source files/globs to test identifiers; the reporter filters
 
 - Delegate to `scan-automation-project`: are there manual `.test.md` cases, which e2e framework exists (unit/integration don't count), do automated tests live in this repo or elsewhere.
 - The result fixes the project kind — manual, automated, or mixed — and with it which flows apply.
-- Investigate the CI with `setup-ci-automation`: which CI system runs PRs and what workflows already exist.
+- Investigate the CI with `setup-ci-automation`: which CI system runs the project, what workflows exist, and which of them deploy — to which environments.
 - Locate the coverage map (default `coverage.tests.yml`). Missing → propose creating it and delegate to `qa-test-code-coverage`.
 
 ### Step 2 — Present the flows and ask the unknowns
@@ -91,65 +93,61 @@ Automated tests found — ❓ choose the execution mode. Each option in the ques
 | Inline — this pipeline          | mobile/simulators, services this pipeline spins up, or an e2e job that already works in this repo             |
 | Cross-repo dispatch             | the e2e suite lives in another repo and no Testomat.io CI profile covers it                                   |
 
-- Remote chosen → identify the Testomat.io CI profile, never guess it: Testomat.io MCP connected → fetch the list, present it, ❓ ask the user to choose (profiles differ by workflow and job names); no MCP → ❓ ask for the exact profile name; none exists yet → creating one in Testomat.io (Settings → CI) is a prerequisite; wire the launch step ready to enable.
+- Remote chosen → identify the Testomat.io CI profile, never guess it: Testomat.io MCP connected → fetch the list, present it, ❓ ask the user to choose (profiles differ by workflow and job names); no MCP → ❓ ask for the exact profile name; none exists yet → creating one in Testomat.io (Settings → CI) is a prerequisite.
+- **Then prove that profile launches before wiring anything around it.** ❓ Ask approval — it executes the full suite. Run `npx @testomatio/reporter run --remote <profile-name>` unfiltered, then check on the CI that a job actually started. Exit code 0 only means Testomat.io accepted the dispatch; a profile aimed at the wrong workflow, job, or branch fails silently. Nothing started → fix in Settings → CI and repeat.
 - No e2e suite anywhere → wire only the manual flow; never fabricate an e2e job.
-
-Then the launch triggers (automated/mixed only):
-
-1. Preview environments — is every commit deployed to a preview server? If yes: what is the observable deploy-finished signal, and where does the preview URL surface?
-2. Post-merge timing — launch right on merge, or wait for a staging/production deploy to finish? A deploy gate needs its own observable signal.
 
 And for every kind:
 
-3. Rungroup strategy — week / day / release / milestone.
+1. ❓ Which deploys trigger the run — the per-PR preview deploy, the post-merge deploy to staging/production, or both. Offer the deploy pipelines found in Step 1. Both exist → wire both; each produces its own run, scoped to what that deploy shipped and tested against that environment.
+2. ❓ Rungroup strategy — week / day / release / milestone.
 
 ### Step 3 — Confirm the selected flow
 
-- Draw the flow the answers produced — only the chosen kind, triggers, and execution mode.
+- Draw the flow the answers produced — only the chosen kind, deploys, and execution mode.
 - ❓ Present the diagram and get approval; wire nothing until the user accepts it.
 
-Example — mixed project, Testomat.io CI profile, previews confirmed:
+Example — mixed project, preview and post-merge deploys, Testomat.io CI profile:
 
 ```mermaid
 flowchart LR
-    PR([PR opened]) --> RUN[Create one mixed run<br/>scoped to the diff]
-    RUN --> TESTERS[Testers execute manual cases<br/>on Testomat.io]
-    RUN --> SCHED[Schedule automated tests —<br/>nothing runs yet]
-    PREV([Preview deployed]) --> L1[Launch automated tests via the<br/>Testomat.io CI profile, against the preview]
-    MERGE([PR merged]) --> L2[Launch automated tests<br/>with the final diff]
-    SCHED -.-> L1
-    SCHED -.-> L2
-    L1 --> RES[Results land in the PR run]
-    L2 --> RES
+    PREV([Preview deploy succeeds]) --> JOB
+    STG([Post-merge deploy succeeds]) --> JOB
+    JOB[Same job — get the PR, create a run<br/>scoped to what this deploy shipped]
+    JOB --> TESTERS[Testers execute manual cases<br/>on Testomat.io]
+    JOB --> L1[Launch automated tests via the Testomat.io<br/>CI profile, against this deploy's environment]
+    L1 --> RES[Results land in that run]
 ```
 
-### Step 4 — Wire the phases into CI
+### Step 4 — Wire the job into CI
 
-Author the jobs following `setup-ci-automation`'s workflow-authoring rules; take every command and env var from `run-tests-with-testomatio-reporter`. Manual-only projects get phase (a) alone. One reporter command per job — no `--filter-list` pre-checks.
+One job in the deploy pipeline, gated on the deploy job succeeding through the CI's native job dependency. The same job serves both deploys — only three things differ:
 
-**(a) PR opened → create the run.**
+| Deploy                  | The PR                            | Diff range                        | Tests run against    |
+| ----------------------- | --------------------------------- | --------------------------------- | -------------------- |
+| Preview deploy (per PR) | the PR that triggered the deploy  | the PR's target branch            | the preview URL      |
+| Post-merge deploy       | resolved from the deployed commit | the deployed push's commit range  | staging / production |
 
-- Use `start` with the coverage filter; pick the run kind matching the project's tests.
-- Set `TESTOMATIO_TITLE` from the CI's PR-number and PR-title variables and nothing else, so the run reads as the PR it belongs to.
-- Set `TESTOMATIO_DESCRIPTION` to a direct link to the PR when the CI exposes its URL.
-- Provide the platform's comment-pipe token on this job too — `start` posts a pending PR comment with the planned tests (tokens per platform in `run-tests-with-testomatio-reporter`).
-- Persist the printed run id with the CI's native value-passing mechanism (artifact, variable, output) — every launch phase reads it; never set up shared-run title matching.
-- Run once per PR (on open); pushes to the PR don't recreate runs.
-- A PR touching no mapped tests is normal — pass `--warn` so `start` exits 0 and the job stays green; never parse the output.
+Author it following `setup-ci-automation`'s workflow-authoring rules; take every command and env var from `run-tests-with-testomatio-reporter`. No `--filter-list` pre-checks. Manual-only projects get (a) and (b) alone.
 
-**(b) Preview deployed → launch against the preview** (only when Step 2 confirmed previews).
+**(a) Get the PR.** A preview deploy already carries it. After a merge, ask the platform which PR contains the deployed commit — never parse the commit subject, which yields the branch name for a merge commit. No PR → log it and exit 0; direct commits to the mainline deploy as before and create nothing.
 
-- Trigger on the deploy-finished signal and only when it reports success — never on the push.
-- Launch into the persisted run id, so results land in the PR's run.
-- Remote mode forwards the preview URL as a remote param; inline mode points the runner's own base-URL env at it.
-- Manual cases need no launch — testers work through them against the preview by hand.
+**(b) Create the run.**
 
-**(c) PR merged → launch with the final diff.**
+- `start --kind detect --format id --warn --filter "coverage:file=<map>,diff=<range>"`, capturing the printed id into `TESTOMATIO_RUN` in the same shell.
+- `<range>` is what this deploy shipped — per the table above.
+- `--kind detect` — a diff touching only manual tests then yields a manual run, not a mixed one with an empty automated half.
+- `TESTOMATIO_TITLE` from the resolved PR's number and title and nothing else; `TESTOMATIO_DESCRIPTION` its URL; `TESTOMATIO_RUNGROUP_TITLE` per Step 2.
+- Provide the platform's comment-pipe token so the reporter posts its PR comment (tokens per platform in `run-tests-with-testomatio-reporter`).
+- A change touching no mapped tests is normal — `--warn` keeps the job green; never parse the output.
+- Check out the deployed revision with full history — the coverage filter diffs.
 
-- Pin the job to the exact revision this PR landed on the mainline and diff against the mainline state just before it — the branch tip moves as later merges or rebases land.
-- Target the persisted run id; pass a fresh coverage filter with the post-merge diff base so the final merged diff decides what runs.
-- Step 2 chose a deploy gate → launch only after that staging/production deploy finishes, on its own observable signal.
-- Cross-repo mode: trigger the e2e repo's pipeline with the CI's native mechanism, passing the run id and API key into it.
+**(c) Launch the automated tests into that run** (automated/mixed only).
+
+- Same filter and same range as (b), so the launch scope matches what the run was created for.
+- Remote: `run --remote <profile-name>`. Inline: `run "<runner command>"`. Cross-repo: trigger the other repo's pipeline with the CI's native mechanism, passing the run id and API key into it.
+- The URL of the environment this deploy produced reaches the tests — a remote param for remote mode, the runner's own base-URL env for inline.
+- Manual cases need no launch — testers work through them against the deployed change by hand.
 
 ### Step 5 — Deliver: secrets and the PR
 
@@ -163,31 +161,29 @@ Provision secrets and open the pipeline PR as `setup-ci-automation` prescribes, 
 
 Prove the pipeline's commands work before the CI ever runs them — by running them once, locally, on a real change.
 
-- ❓ Ask the user for a real PR to validate with — open or already merged — and for approval to create real runs.
-- Reproduce the pipeline's diff locally: open PR → check out its branch and diff against the target branch; merged PR → check out the merge commit and diff against the pre-merge tip.
-- Create the run exactly as phase (a) does — same kind, same filter, and the title that PR's own title yields.
-- Open PR → stop here: the run stays scheduled, nothing executes.
-- Merged PR → the change is already in mainline, so launching is safe: run the phase (c) launch against the created run.
-- Report every run created — id, kind, and the tests it scoped — and ask the user to review it in Testomat.io: does the scope match what that diff should affect?
+- ❓ Ask the user for a PR to validate with, and for approval to create a real run and launch tests — an open PR when a preview deploy is wired, an already-merged one otherwise.
+- Reproduce that deploy's diff locally, per the Step 4 table: open PR → check out its branch and diff against the target branch; merged PR → check out the merge commit and diff against the mainline state just before it.
+- Create the run exactly as (b) does — same kind, same filter, and the title that PR's own title yields — then launch as (c) does into it.
+- Report the run created — id, kind, and the tests it scoped — and ask the user to review it in Testomat.io: does the scope match what that diff should affect?
 - Zero tests matched → report it as a finding, then pick a PR that touches mapped source files together with the user.
 
 ### Step 7 — Summarize and hand off
 
-Present the approved flow diagram once more, now marked as wired. Report: the CI targeted and files written; which phases are wired and which were skipped (no previews / no e2e / no Testomat.io CI profile); the chosen execution mode; title scheme and rungroup; the run-id carrier the launch steps read; the battle-test outcome and the runs awaiting the user's review; secrets and prerequisites still to provision; assumptions to confirm. Recommend committing the coverage map alongside the CI config.
+Present the approved flow diagram once more, now marked as wired. Report: the CI targeted and files written; the deploys the job hangs off; the chosen execution mode and the Testomat.io CI profile check result; what was skipped (no e2e / no Testomat.io CI profile); title scheme and rungroup; the battle-test outcome and the run awaiting the user's review; secrets and prerequisites still to provision; assumptions to confirm. Recommend committing the coverage map alongside the CI config.
 
 ## Examples
 
-**Example 1 — mixed project, previews, Testomat.io CI profile**
-Discovery finds manual cases and an e2e suite; MCP lists the Testomat.io CI profiles and the user picks the one running the e2e suite; previews confirmed. → Diagram approved, then all three phases wired: mixed run on PR open, preview launch gated on the deployment-success event with the preview URL as a remote param, merge launch with a fresh post-merge filter. Comment pipe enabled.
+**Example 1 — mixed project, preview and post-merge deploys, Testomat.io CI profile**
+Discovery finds manual cases, an e2e suite, a per-PR preview deploy and a deploy to staging on the mainline; MCP lists the Testomat.io CI profiles and the user picks the one running the e2e suite. → The profile is proven with an unfiltered `run --remote` and a check that a job started, the diagram is approved, then the same job is added to both deploy pipelines: get the PR, `start --kind detect` with the coverage filter for that deploy's range, launch remotely against that deploy's URL. Two runs per PR — one on the preview, one on staging. Comment pipe enabled.
 
 **Example 2 — e2e lives in another repo, no Testomat.io CI profile**
-The user picks cross-repo dispatch from the mode table: the merge job triggers the e2e repo's pipeline via the CI's native mechanism, passing the run id so results land in the prepared run. Note the Testomat.io CI profile option as the simpler future path.
+The user picks cross-repo dispatch from the mode table: the same job creates the run, then triggers the e2e repo's pipeline via the CI's native mechanism, passing the run id so results land in it. Note the Testomat.io CI profile option as the simpler future path.
 
 **Example 3 — no coverage map yet**
 No `coverage*.yml` found → explain nothing can be filtered without a map; delegate to `qa-test-code-coverage`; wire CI only after the map exists.
 
 **Example 4 — manual-only project**
-`scan-automation-project` finds `.test.md` cases and no e2e framework → the flows diagram shows only the manual branch; no execution-mode or trigger questions asked. One phase wired: a manual run per PR, complete at creation — testers start on Testomat.io. Explain that launch phases need an e2e suite first.
+`scan-automation-project` finds `.test.md` cases and no e2e framework → the flows diagram shows only the manual branch; no execution-mode question asked. The job resolves the PR and creates the run, complete at creation — testers start on Testomat.io against the deployed change. Explain that launching needs an e2e suite first.
 
 ## Related skills
 

--- a/skills/setup-ci-automation/SKILL.md
+++ b/skills/setup-ci-automation/SKILL.md
@@ -68,7 +68,7 @@ Tasks worth wiring to CI events — the named skill owns each task's content:
 | ------------- | ----------------------------------------------------------- | ---------------------------------------------------- |
 | PR opened     | Generate test cases from the PR diff                        | `pull-request-diff-analyzer` + `qa-write-test-cases` |
 | Issue opened  | QA-analyze the feature — edge cases, acceptance criteria    | `qa-thinking`                                        |
-| PR opened     | Create a scoped test run, launch affected tests             | `setup-change-aware-pr-testing`                      |
+| Deploy done   | Create a scoped test run, launch affected tests             | `setup-change-aware-pr-testing`                      |
 | Schedule      | Detect duplicate or overlapping test cases                  | `detect-duplicate-test-cases`                        |
 
 ## Related skills


### PR DESCRIPTION
Matches [testomatio/testomatio#9748](https://github.com/testomatio/testomatio/pull/9748), which replaced a two-workflow PR testing setup with one job gated on the deploy.

The minimal setup is one job that creates the run and launches the tests together, so tests run against deployed code. A split across two jobs stays available when a project needs it.

## Preview and post-merge deploys are unified

Both are equally valid triggers — the same job serves both, and a project with both wires both. Step 4 tables the only three things that differ:

| Deploy | The PR | Diff range | Tests run against |
| --- | --- | --- | --- |
| Preview deploy (per PR) | the PR that triggered the deploy | the PR's target branch | the preview URL |
| Post-merge deploy | resolved from the deployed commit | the deployed push's commit range | staging / production |

## Changes

`setup-change-aware-pr-testing` (4.0.0 → 5.0.0), net **4 lines shorter**:

- Flows diagram: preview or post-merge deploy succeeds → PR behind this commit? → create run → launch. The old `schedule, then launch later` fork is gone.
- Step 2 asks which deploys trigger the run — preview, post-merge, or both.
- Step 4 wires one job instead of three phases, with the table above covering both deploys.
- Constraints: a deployed commit with no PR creates nothing; the job never fails the deploy pipeline; `--kind detect` over hardcoded `mixed`.
- Battle-test uses an open PR when a preview deploy is wired, a merged one otherwise.

**New in Step 2** — remote mode is gated on proving the Testomat.io CI profile works: unfiltered `npx @testomatio/reporter run --remote <profile-name>`, then check on the CI that a job actually started. Exit 0 only means the dispatch was accepted, so a profile aimed at the wrong workflow, job or branch fails silently.

Two supporting one-liners: `--kind detect` gets a row in `run-tests-with-testomatio-reporter`'s kind table ([reporter#907](https://github.com/testomatio/reporter/pull/907)), and `setup-ci-automation`'s automation-ideas table now says "Deploy done" rather than "PR opened".

Kept CI-agnostic throughout — no platform-specific event names or API paths.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
