### PR TITLE
feat: add qa-explain-behavior skill

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -18,6 +18,11 @@
       "description": "Adds a /test-automation skill for test automation (create, heal, sync results, etc)"
     },
     {
+      "name": "qa-process",
+      "source": "./plugins/qa-process",
+      "description": "Strategic QA process advisory — assess QA maturity, prioritize a roadmap, explain product behavior, think through quality risks, and orchestrate the test lifecycle"
+    },
+    {
       "name": "explorbot",
       "source": "./plugins/explorbot",
       "description": "Adds /explorbot-setup, /explorbot-fundamentals and /explorbot-plan skills to install, configure, run, debug and plan Explorbot autonomous AI web tests"

--- a/BA_USER_STORIES_AND_WORKFLOWS.md
+++ b/BA_USER_STORIES_AND_WORKFLOWS.md
@@ -1,0 +1,998 @@
+# User Stories & Workflows for Testomatio AI Skills
+
+## Overview
+
+This document provides detailed Business Analyst perspective on each skill including user stories, workflows, and value propositions.
+
+---
+
+## 1. 🎯 GENERATE-CASES Skill
+
+### Purpose
+Generate comprehensive test cases and checklists for software testing from requirements, user stories, designs, or freestyle input.
+
+### User Stories
+
+**Story 1.1: QA Engineer Creates Test Cases from Ticket**
+- **As a** QA Engineer
+- **I want to** generate test cases from a Jira ticket
+- **So that** I have structured test coverage without manual documentation
+
+**Story 1.2: Product Manager Validates User Flows**
+- **As a** Product Manager
+- **I want to** create a comprehensive checklist for a feature from a design mockup
+- **So that** I ensure all user journeys are covered before development
+
+**Story 1.3: Dev Team Plans Testing Strategy**
+- **As a** Development Team Lead
+- **I want to** generate different coverage levels (smoke, balanced, exhaustive)
+- **So that** I can match testing scope to sprint capacity
+
+### Workflow
+
+```
+Step 1: Gather Context & Goals
+├─ User provides: requirements, ticket, design, or freestyle description
+├─ Skill analyzes context
+├─ User approves: sources and any additions
+
+Step 2: Select Coverage Scope
+├─ 🚀 Smoke Test (minimal coverage)
+├─ ⚖️  Balanced (comprehensive)
+├─ 🧨 Exhaustive (maximum coverage)
+└─ User selects scope
+
+Step 3: Choose Role/Perspective (Optional)
+├─ ⚙️  Default (Happy path)
+├─ 🔍 QA Lead (Quality-focused)
+├─ 😈 Pessimist (Edge cases)
+├─ 🎭 User (User-centric)
+└─ User selects role or keeps default
+
+Step 4: Generate & Approve Checklist
+├─ Skill generates categorized checklist
+├─ User reviews and approves/modifies
+└─ User confirms ready for test cases
+
+Step 5: Generate Detailed Test Cases
+├─ Skill converts checklist to markdown test cases
+├─ Each test case includes: title, description, steps, expected results
+└─ Test cases ready for use/upload
+```
+
+### Output
+- Structured checklist with categorized test items
+- Markdown test cases in Testomatio format
+- Optional: Test case IDs and metadata
+
+### Value Proposition
+- **Saves time**: 4-6 hours of manual test case writing per feature
+- **Ensures consistency**: Standardized format across team
+- **Improves coverage**: No missed user flows or edge cases
+- **Enables collaboration**: Clear, structured documentation
+
+---
+
+## 2. 📝 IMPROVE-TEST-CASES Skill
+
+### Purpose
+Enhance existing markdown manual test cases for clarity, structure, and compliance with Test Management Tool format.
+
+### User Stories
+
+**Story 2.1: QA Lead Standardizes Legacy Test Cases**
+- **As a** QA Lead
+- **I want to** standardize all manually-written test cases to TMS format
+- **So that** the team has consistent documentation and can easily search/filter
+
+**Story 2.2: Test Author Fixes Formatting Issues**
+- **As a** Test Author
+- **I want to** improve clarity of ambiguous test steps
+- **So that** other QA engineers can execute tests without confusion
+
+**Story 2.3: Quality Audit Before Migration**
+- **As a** QA Manager
+- **I want to** audit test cases before importing to new TMS
+- **So that** we don't carry forward quality issues
+
+### Workflow
+
+```
+Step 1: Locate Test Files
+├─ Scan common directories: ./manual-tests, ./tests/manual, ./docs/tests
+└─ Ask user if no files found
+
+Step 2: Analyze Test Quality
+├─ Title clarity (vague vs. specific)
+├─ Description completeness
+├─ Step formatting & ordering
+├─ Expected results clarity
+├─ Metadata consistency
+└─ Generate issue summary
+
+Step 3: Show Summary & Get Approval
+├─ Display issues found per test
+├─ Show specific recommendations
+└─ Wait for user confirmation
+
+Step 4: Apply Improvements
+├─ Clarify titles to action-result format
+├─ Enhance descriptions
+├─ Fix markdown syntax
+├─ Ensure expected results per step
+├─ Standardize metadata
+└─ Preserve original test IDs
+
+Step 5: Save & Summarize
+├─ Overwrite original files with improved versions
+├─ Report: files modified, tests improved, key improvements
+└─ Suggest next steps
+```
+
+### Output
+- Improved markdown test files
+- Summary of changes made
+- Ready for upload to TMS
+
+### Common Improvements
+- Unclear title → "Verify user can save profile with valid data"
+- Missing expected results → Added specific, measurable outcomes
+- Inconsistent formatting → Standardized to TMS markdown
+- Vague language → Replaced subjective terms with specific conditions
+
+### Value Proposition
+- **Improves executability**: Tests are clear and unambiguous
+- **Reduces execution time**: QA spends less time interpreting steps
+- **Enables automation**: Clear tests are easier to automate
+- **Professional quality**: Standardized format for stakeholder presentations
+
+---
+
+## 3. 🔍 FIND-DUPLICATE-CASES Skill
+
+### Purpose
+Detect and manage duplicate, near-duplicate, and overlapping test cases; provide cleanup recommendations.
+
+### User Stories
+
+**Story 3.1: QA Lead Audits Test Suite**
+- **As a** QA Lead
+- **I want to** identify duplicate tests across our manual and automated test suites
+- **So that** we reduce maintenance burden and avoid redundant execution
+
+**Story 3.2: Consultant Evaluates Test Quality**
+- **As a** QA Consultant
+- **I want to** analyze a large test suite for redundancy
+- **So that** I can recommend consolidation and improve team efficiency
+
+**Story 3.3: Team Prepares for TMS Migration**
+- **As a** QA Team
+- **I want to** clean up tests before migrating to new TMS
+- **So that** we start fresh without technical debt
+
+### Workflow
+
+```
+Step 1: Detect Test Files
+├─ Identify manual tests (*.test.md, *.feature)
+├─ Identify automated tests (*.spec.ts, *.test.js, *.cy.js)
+└─ Parse test metadata: title, steps, expected results, tags
+
+Step 2: Analyze for Duplicates
+├─ Normalize content (lowercase, remove punctuation, ignore framework syntax)
+├─ Compare: title, steps, expected results, preconditions, tags
+├─ Calculate similarity scores
+├─ Classify into levels:
+│  ├─ Level 1: Exact duplicates (identical titles)
+│  ├─ Level 2: Semantic duplicates (same intent, similar steps)
+│  ├─ Level 3: Overlapping/Subset (superset/subset relationship)
+│  └─ Level 4: Redundant variations (same logic, different data)
+└─ Build duplicate groups
+
+Step 3: Generate Report
+├─ Summary statistics
+├─ Duplicate groups with:
+│  ├─ All related tests
+│  ├─ Similarity percentage
+│  ├─ Detection level
+│  ├─ Proposed canonical test
+│  └─ Recommendation (keep/merge/remove)
+└─ Wait for user approval
+
+Step 4: Execute Actions
+├─ Merge: Combine into one test, retain metadata from all
+├─ Remove: Delete duplicates, add reference in canonical
+├─ Keep: Document relationship with cross-references
+└─ Preserve all traceability metadata
+```
+
+### Output
+- Duplicate analysis report
+- Classification and recommendations
+- Merged/cleaned test suite
+
+### Value Proposition
+- **Reduces maintenance**: 20-30% fewer tests to maintain
+- **Faster test runs**: Eliminates redundant execution
+- **Better coverage**: Real coverage visibility without noise
+- **Team efficiency**: QA focuses on new scenarios, not duplicates
+
+---
+
+## 4. 🔄 SYNC-CASES Skill
+
+### Purpose
+Synchronize test cases between local Markdown files and Testomat.io Test Management System.
+
+### User Stories
+
+**Story 4.1: QA Team Bulk Edits Tests Offline**
+- **As a** QA Team
+- **I want to** pull test cases from Testomat.io, edit them in my IDE, and push them back
+- **So that** I can use powerful IDE features for bulk editing
+
+**Story 4.2: Developer Imports Generated Tests**
+- **As a** Developer
+- **I want to** generate test cases locally and upload them to Testomat.io
+- **So that** the team can see the tests in our TMS immediately
+
+**Story 4.3: Backup & Version Control**
+- **As a** QA Manager
+- **I want to** maintain local backups of tests from Testomat.io
+- **So that** we have version history and disaster recovery
+
+### Workflow - Pull Operation
+
+```
+Step 1: Setup Environment
+├─ Check for TESTOMATIO token in .env
+├─ If missing, ask user for API key
+└─ Save token to .env file
+
+Step 2: Pull Tests
+├─ Ensure .testclaw-context/ directory exists
+├─ Add .testclaw-context/ to .gitignore if needed
+├─ Run: npx check-tests pull -d .testclaw-context/manual-tests
+└─ Tests downloaded as markdown files
+
+Step 3: Summary
+├─ Number of tests pulled
+├─ File locations
+└─ Ready for editing
+```
+
+### Workflow - Push Operation
+
+```
+Step 1: Validate Files
+├─ Check for *.test.md files
+├─ Verify valid test blocks (<!-- test ... -->)
+├─ Exclude documentation files (README, docs/)
+└─ Build list of files to push
+
+Step 2: Push Tests
+├─ Run: npx check-tests push --files <files>
+└─ Tests uploaded to Testomat.io
+
+Step 3: Summary
+├─ Number of tests pushed
+├─ Status of each test (created/updated)
+└─ Links to TMS
+```
+
+### Complete Workflow: Bulk Edit Cycle
+
+```
+1. Pull tests → 2. Edit locally → 3. Push back
+```
+
+### Output
+- Markdown test files (pull)
+- Uploaded tests in Testomat.io (push)
+- Summary report
+
+### Value Proposition
+- **Flexible editing**: Use IDE for advanced editing tasks
+- **Batch operations**: Update multiple tests at once
+- **Version control**: Keep local copies in git
+- **Team collaboration**: Merge changes from team members
+
+---
+
+## 5. 📊 MANUAL-COVERAGE Skill
+
+### Purpose
+Map manual test cases to source code files; generate `coverage.manual.yml` for affected-only test runs.
+
+### User Stories
+
+**Story 5.1: QA Lead Runs Selective Regression**
+- **As a** QA Lead
+- **I want to** run only manual tests affected by a code change
+- **So that** we reduce regression testing time from 8 hours to 2 hours
+
+**Story 5.2: DevOps Creates Smart Test Pipelines**
+- **As a** DevOps Engineer
+- **I want to** automatically select manual tests based on code diff in CI
+- **So that** PR pipelines are faster and provide relevant feedback
+
+**Story 5.3: QA Manager Tracks Traceability**
+- **As a** QA Manager
+- **I want to** see which manual tests cover which source files
+- **So that** I can identify coverage gaps and validate completeness
+
+### Workflow
+
+```
+Step 1: Discover Project
+├─ Run project-scan skill
+├─ Identify manual tests (.test.md files)
+├─ Get codebase overview
+└─ If no manual tests found, ask to pull from Testomat.io
+
+Step 2: Extract Test Information
+├─ Parse *.test.md files
+├─ Extract: Suite IDs (@S), Test IDs (@T), Tags (@tag)
+├─ Build mapping of test metadata to files
+└─ If no IDs found, ask user to sync with Testomat.io first
+
+Step 3: Explore Codebase
+├─ Scan source files
+├─ Identify code areas (auth, checkout, profile, etc.)
+├─ Build code map
+└─ Identify file patterns and naming conventions
+
+Step 4: Map Tests to Code
+├─ For each test, analyze steps and expected results
+├─ Match test scenarios to source files they exercise
+├─ Build mapping: source file → test IDs
+├─ Handle edge cases and ambiguous mappings
+└─ Get user approval for mappings
+
+Step 5: Generate coverage.manual.yml
+├─ Create YAML mapping file
+├─ Format: source files/globs → suite/test IDs
+├─ Validate coverage file
+└─ Save to project root or specified path
+
+Step 6: Summary
+├─ Coverage statistics
+├─ Identified gaps
+├─ Recommendations
+└─ Ready for use with reporter
+```
+
+### Output
+- `coverage.manual.yml` file
+- Coverage report (% of code covered)
+- Gap analysis
+
+### Coverage File Format
+```yaml
+src/auth/login.ts:
+  - "@T12345abc"
+  - "@tag.smoke"
+  
+src/checkout/**:
+  - "@S87654def"
+  - "@tag.critical"
+```
+
+### Value Proposition
+- **Faster feedback**: Run only relevant tests
+- **Better ROI on testing**: No time wasted on irrelevant tests
+- **Traceability**: Clear requirements-to-code-to-test mapping
+- **Quality insights**: Identify untested code areas
+
+---
+
+## 6. 🤖 AUTOMATION-COVERAGE Skill
+
+### Purpose
+Map automated e2e tests to source code files; generate `coverage.e2e.yml` for affected-only test runs.
+
+### User Stories
+
+**Story 6.1: CI/CD Pipeline Optimization**
+- **As a** DevOps Engineer
+- **I want to** run only e2e tests relevant to a PR change
+- **So that** CI pipelines run 5x faster while maintaining quality
+
+**Story 6.2: QA Team Prioritizes Test Execution**
+- **As a** QA Lead
+- **I want to** understand which e2e tests validate which features
+- **So that** we can run the right tests at the right time
+
+**Story 6.3: Traceability Matrix**
+- **As a** QA Manager  
+- **I want to** build a traceability matrix between code and e2e tests
+- **So that** we can validate coverage against requirements
+
+### Workflow (Similar to manual-coverage, but for automated tests)
+
+```
+Step 1: Discover Project
+├─ Run project-scan skill
+├─ Detect e2e framework (Playwright, Cypress, WebdriverIO, CodeceptJS)
+├─ Identify e2e test files
+└─ If no tests found, ask for git URL to clone tests repo
+
+Step 2: Verify Testomatio IDs
+├─ Check for @S/@T IDs in test code
+├─ Example: describe('login @S123abc', () => {})
+├─ If missing, instruct user to run: npx check-tests <framework> --update-ids
+└─ Stop if IDs cannot be populated
+
+Step 3-6: [Same as manual-coverage]
+```
+
+### Output
+- `coverage.e2e.yml` file
+- Used with: `@testomatio/reporter run --filter "coverage:file=coverage.e2e.yml,diff=main"`
+
+### Value Proposition
+- **Massive speed improvement**: 10-20x faster CI for large suites
+- **Smart feedback**: Developers get relevant test results immediately
+- **Cost savings**: Fewer test hours = lower infrastructure costs
+- **Better quality**: Tests run more frequently, bugs caught sooner
+
+---
+
+## 7. 🔧 REPORTER-SETUP Skill
+
+### Purpose
+Detect framework and set up Testomat.io reporting for test automation projects.
+
+### User Stories
+
+**Story 7.1: Team Integrates New Test Suite**
+- **As a** QA Lead
+- **I want to** set up Testomat.io reporting for our Playwright tests
+- **So that** test results automatically appear in our TMS
+
+**Story 7.2: Multi-Framework Project Setup**
+- **As a** QA Architect
+- **I want to** configure reporting for Jest (unit tests), Playwright (e2e), and Pytest (API tests)
+- **So that** all test results are centralized in one place
+
+**Story 7.3: Developer Onboarding**
+- **As a** New Developer
+- **I want to** quickly set up test reporting without manual configuration
+- **So that** I can contribute tests on day one
+
+### Workflow
+
+```
+Step 1: Detect Project Language & Framework
+├─ Scan package.json, requirements.txt, pom.xml, etc.
+├─ Identify language (JavaScript, Python, Java, C#, PHP, Ruby, etc.)
+├─ Detect test framework:
+│  ├─ JS: Playwright, CodeceptJS, WebdriverIO, Jest, Mocha, Cypress
+│  ├─ Python: Pytest, Robot Framework
+│  ├─ Java: JUnit, TestNG
+│  └─ XML: Generic XML reporter
+├─ If framework unknown, ask user to specify
+└─ Proceed to Step 2
+
+Step 2: Install Reporter Package
+├─ Install @testomatio/reporter package
+├─ Or install framework-specific reporter
+└─ Add to package.json/requirements.txt
+
+Step 3: Configure Reporter
+├─ Get TESTOMATIO API key from user
+├─ Update configuration file (playwright.config.ts, jest.config.js, etc.)
+├─ Add reporter initialization code
+└─ Set environment variables
+
+Step 4: Verify Setup
+├─ Run sample test
+├─ Confirm results appear in Testomat.io
+└─ Provide summary and next steps
+
+Step 5: Documentation
+├─ Generate setup instructions
+├─ Explain how to run tests with reporting
+├─ Provide CI/CD examples
+└─ Done
+```
+
+### Output
+- Installed and configured reporter
+- Example test run with reporting
+- CI/CD setup instructions
+
+### Supported Frameworks
+- **JavaScript/TypeScript**: Playwright, CodeceptJS, WebdriverIO, Jest, Mocha, Cypress
+- **Python**: Pytest, Robot Framework
+- **Java**: JUnit, TestNG
+- **Other**: XML report format
+
+### Value Proposition
+- **Zero manual configuration**: AI detects and configures automatically
+- **Centralized reporting**: All test results in one place
+- **Better visibility**: Team sees all test metrics
+- **CI integration ready**: Reporting works in CI/CD pipelines
+
+---
+
+## 8. 🔎 PROJECT-SCAN Skill
+
+### Purpose
+Scan project source code to inventory languages, frameworks, and existing tests.
+
+### User Stories
+
+**Story 8.1: QA Lead Audits Project**
+- **As a** QA Lead  
+- **I want to** understand what tests already exist and which frameworks are used
+- **So that** I can plan new automation without duplicating existing work
+
+**Story 8.2: New Team Member Onboarding**
+- **As a** New QA Engineer
+- **I want to** quickly understand the project's testing infrastructure
+- **So that** I can contribute test cases within the first day
+
+**Story 8.3: Testing Architecture Decision**
+- **As a** Tech Lead
+- **I want to** see all testing frameworks in use across the project
+- **So that** I can make informed decisions about standardization
+
+### Workflow
+
+```
+Step 1: Understand Project Context
+├─ Scan root directory
+├─ Look for source code files
+├─ If no source found, ask user:
+│  ├─ Provide path to source code
+│  ├─ Clone from git repo
+│  └─ Or stop
+└─ Continue if source found
+
+Step 2: Detect Languages
+├─ Scan for package.json → JavaScript/TypeScript
+├─ Scan for requirements.txt → Python
+├─ Scan for pom.xml → Java
+├─ Scan for Go, Rust, C#, Ruby, PHP files
+└─ List all detected languages
+
+Step 3: Detect Frameworks
+├─ JavaScript: Look for Jest, Mocha, Playwright, Cypress, CodeceptJS configs
+├─ Python: Look for pytest, robot, unittest
+├─ Java: Look for TestNG, JUnit, Maven/Gradle
+└─ Identify each framework's test files
+
+Step 4: Inventory Manual Tests
+├─ Find *.test.md files
+├─ Count and list them
+├─ Group by directory
+└─ Show summary
+
+Step 5: Inventory Automated Tests
+├─ Find test files by pattern: *.spec.ts, *.test.js, *.cy.js, etc.
+├─ Count by framework and type (unit, e2e, integration)
+├─ Group by directory
+└─ Show summary
+
+Step 6: Generate Report
+├─ Project overview
+├─ Language/framework matrix
+├─ Test inventory (manual + automated)
+├─ Recommendations for next steps
+└─ Done
+```
+
+### Output
+- Project inventory report
+- Languages and frameworks detected
+- List of existing tests
+- Test coverage overview
+
+### Value Proposition
+- **Quick onboarding**: New team members understand project in minutes
+- **Gap identification**: See what's tested and what's not
+- **Architecture visibility**: Understand test infrastructure
+- **Planning basis**: Informed decisions on next testing steps
+
+---
+
+## 9. 🚀 AUTOMATE-TEST-CASES Skill
+
+### Purpose
+Convert manual test cases into production-ready automated test scripts.
+
+### User Stories
+
+**Story 9.1: QA Engineer Automates Key Flows**
+- **As a** QA Engineer
+- **I want to** convert our critical manual test cases into automation
+- **So that** they run automatically in every build
+
+**Story 9.2: Increase Automation Coverage**
+- **As a** QA Lead
+- **I want to** automate 50% of our manual test cases
+- **So that** we reduce manual execution time and catch bugs faster
+
+**Story 9.3: Maintain Quality During Transition**
+- **As a** QA Manager
+- **I want to** ensure automated tests match the intent of manual tests
+- **So that** we don't lose coverage during the transition
+
+### Workflow (5-Step Process)
+
+```
+Step 1: Analyze Project Architecture
+├─ Detect framework (Playwright, CodeceptJS, etc.)
+├─ Find reusable components (Page Object Model, helpers)
+├─ Identify test execution patterns
+└─ Build understanding of project structure
+
+Step 2: Understand Manual Test
+├─ Normalize test steps
+├─ Handle ambiguous or unclear steps
+├─ Detect any inconsistencies
+└─ Get clarification if needed
+
+Step 3: Write Test Code
+├─ Implement using existing patterns
+├─ Add assertions
+├─ Follow project conventions
+└─ Output generated test script
+
+Step 4: Verify & Heal (up to 3 attempts)
+├─ Execute test
+├─ If fails:
+│  ├─ Try locator fixes
+│  ├─ Try timing adjustments
+│  ├─ Try assertion corrections
+│  └─ Try flow adjustments
+├─ If passes 3 times → Stop loop
+└─ If fails 3 times → Ask user for help
+
+Step 5: Finalization
+├─ Ensure structure compliance
+├─ Manage test data & fixtures
+├─ Run related tests to check for side effects
+└─ Output summary
+```
+
+### Output
+- Automated test script in project framework
+- Test passes locally
+- Ready for CI integration
+
+### Value Proposition
+- **Dramatically reduces automation effort**: Manual → Automated in minutes
+- **Maintains quality**: AI ensures tests match manual intent
+- **Prevents defects**: Auto-healing fixes common issues automatically
+- **Faster delivery**: Team gets automation without extra training
+
+---
+
+## 10. 🐛 AUTOMATION-DEBUG-TESTS Skill
+
+### Purpose
+Diagnose and fix failing automated tests systematically.
+
+### User Stories
+
+**Story 10.1: Fix Flaky Tests**
+- **As a** QA Engineer
+- **I want to** fix tests that pass locally but fail in CI
+- **So that** our pipeline is reliable and developers trust test results
+
+**Story 10.2: Rapid Test Healing**
+- **As a** Tech Lead
+- **I want to** quickly diagnose why a test failed
+- **So that** we can fix issues and merge code faster
+
+**Story 10.3: Improve Test Stability**
+- **As a** QA Team
+- **I want to** systematically fix timing issues in our e2e tests
+- **So that** tests run reliably across all environments
+
+### Workflow (4-Step Process)
+
+```
+Step 1: Analyze Failure
+├─ Identify error type: locator, timing, assertion, flow, infrastructure
+├─ Capture test name, file, line number
+├─ Collect stack trace, screenshot, video, logs
+├─ Diagnose environment: browser, viewport, CI/local
+└─ Form initial hypothesis
+
+Step 2: Inspect & Diagnose
+├─ DOM inspection: check element presence/visibility
+├─ Network logs: check for failed requests
+├─ Console logs: look for JavaScript errors
+├─ Trace analysis: review timing of actions
+└─ Identify root cause
+
+Step 3: Apply Fix (Priority Order)
+├─ First: Locator issues (update selectors)
+├─ Second: Timing issues (adjust waits, retry logic)
+├─ Third: Assertion issues (fix expected values)
+├─ Fourth: Flow issues (check navigation, preconditions)
+└─ Apply chosen fix
+
+Step 4: Verify & Stabilize
+├─ Re-run test
+├─ Confirm it passes consistently
+├─ Run related tests to check side effects
+├─ Document the fix
+└─ Done
+```
+
+### Output
+- Fixed test
+- Documented fix explanation
+- Verification that fix is stable
+
+### Common Fixes
+- **Locator**: `cy.get('.btn-save')` → `cy.get('[data-test="save-btn"]')`
+- **Timing**: Add `cy.wait(500)` before assertion
+- **Assertion**: Update expected value to match actual behavior
+- **Flow**: Add missing login step before checking profile
+
+### Value Proposition
+- **Saves hours of debugging**: AI diagnoses root cause automatically
+- **Reduces flakiness**: Systematic approach to stabilization
+- **Team productivity**: Engineers focus on features, not test failures
+- **Pipeline reliability**: CI/CD becomes trustworthy
+
+---
+
+## 11. 🎯 TESTOMATIO-FLOW Skill
+
+### Purpose
+Orchestrate the complete test case lifecycle from requirements to uploading to TMS.
+
+### User Stories
+
+**Story 11.1: End-to-End Feature Testing**
+- **As a** QA Lead
+- **I want to** manage the complete testing workflow for a new feature in one session
+- **So that** nothing falls through the cracks and tests are ready for automation
+
+**Story 11.2: Bulk Test Management**
+- **As a** QA Manager
+- **I want to** generate, improve, and upload test cases in one coordinated workflow
+- **So that** tests reach the TMS quickly without manual handoff
+
+**Story 11.3: Smart Task Routing**
+- **As a** QA Engineer
+- **I want to** get intelligent suggestions on what to do next in the testing workflow
+- **So that** I don't need to decide between multiple skills manually
+
+### Workflow (Dynamic & Context-Aware)
+
+```
+Entry: User provides request
+├─ User: "Generate test cases for user registration"
+│
+├─ Skill analyzes request
+├─ Skill gathers context (project structure, existing tests)
+├─ Skill routes to appropriate sub-skill
+│
+├─ Flow 1: Generate → Suggest Upload & Reporter
+│ ├─ Use generate-cases
+│ └─ Suggest: Upload to Testomat.io, Add reporter, Add edge cases
+│
+├─ Flow 2: Improve → Suggest Upload
+│ ├─ Use improve-test-cases
+│ └─ Suggest: Upload updated cases to Testomat.io
+│
+├─ Flow 3: Setup → Suggest Generate
+│ ├─ Use reporter-setup
+│ └─ Suggest: Generate test cases, Map coverage
+│
+├─ Flow 4: Coverage → Suggest Report Review
+│ ├─ Use manual-coverage / automation-coverage
+│ └─ Suggest: Review gaps, Run affected tests
+│
+└─ And more...
+```
+
+### Supported Workflows
+
+**Test Generation Flow**
+```
+Generate → Improve → Upload → Setup Reporter → Map Coverage
+```
+
+**Test Automation Flow**
+```
+Generate → Automate → Debug → Setup Reporter → Map Coverage
+```
+
+**Coverage Optimization Flow**
+```
+Scan → Manual Coverage → Automation Coverage → Review Results
+```
+
+**Bulk Edit Flow**
+```
+Pull → Edit → Push → Verify in TMS
+```
+
+### Output
+- Completed test cases in TMS
+- Configured reporter
+- Coverage mappings
+- Intelligent next steps
+
+### Value Proposition
+- **Simplified workflow**: One entry point instead of choosing between 7+ skills
+- **Intelligent guidance**: AI suggests logical next steps
+- **Reduced context switching**: Flow guides you through related tasks
+- **Complete lifecycle**: From requirement to automation in one session
+
+---
+
+## 12. 🔗 TESTOMATIO-MCP Skill
+
+### Purpose
+MCP (Model Context Protocol) integration with Testomat.io for direct TMS access and automation.
+
+### User Stories
+
+**Story 12.1: Real-Time TMS Operations**
+- **As a** QA Engineer
+- **I want to** query tests, suites, and requirements directly from Testomat.io
+- **So that** I have live data for test generation and planning
+
+**Story 12.2: Automated Sync in Workflows**
+- **As a** QA Team
+- **I want to** integrate Testomat.io data into our AI-powered workflows
+- **So that** we work with live TMS data instead of exported files
+
+**Story 12.3: Rich Context for Test Creation**
+- **As a** QA Engineer
+- **I want to** leverage existing TMS structure (suites, tags, requirements) when generating tests
+- **So that** new tests integrate seamlessly with existing organization
+
+### Workflow
+
+```
+Step 1: Connect to Testomat.io
+├─ Authenticate with API key
+└─ Establish MCP connection
+
+Step 2: Query TMS Data
+├─ List projects, suites, tests
+├─ Search tests by criteria
+├─ Get shared steps
+├─ Retrieve tags and labels
+└─ Access requirements/traceability
+
+Step 3: Integrate with Skills
+├─ Generate-cases: Pull structure, avoid duplicates
+├─ Sync-cases: Automatic bidirectional sync
+├─ Coverage: Link to TMS requirements
+└─ Reporter: Direct result submission
+
+Step 4: Maintain Sync
+├─ Real-time TMS updates
+├─ Automatic ID assignment
+└─ Metadata consistency
+```
+
+### Output
+- Direct TMS integration
+- Live data-driven workflows
+- Automated sync
+
+### Value Proposition
+- **Live data**: Always working with current TMS state
+- **Seamless integration**: No manual export/import
+- **Rich context**: AI understands TMS structure
+- **Reduced friction**: Automatic sync and ID management
+
+---
+
+## Cross-Skill Value Proposition
+
+### Complete Testing Lifecycle
+
+| Phase | Skills Used | Outcome |
+|-------|------------|---------|
+| **1. Plan** | project-scan, generate-cases | Test cases ready for execution |
+| **2. Design** | generate-cases, improve-test-cases | Polished test documentation |
+| **3. Organize** | find-duplicate-cases, sync-cases | Clean test suite in TMS |
+| **4. Automate** | automate-test-cases, reporter-setup | Automation running in CI |
+| **5. Optimize** | manual-coverage, automation-coverage | Smart test selection |
+| **6. Maintain** | automation-debug-tests, improve-test-cases | Healthy test suite |
+
+### Time Savings Examples
+
+- **Generate test cases**: 4-6 hours → 15 minutes (AI generates, you review)
+- **Improve test suite**: 2-3 days → 1 hour (bulk improvements)
+- **Find duplicates**: 4-8 hours → 10 minutes (AI detects, you decide)
+- **Set up automation**: 8-16 hours → 30 minutes (auto framework detection)
+- **Fix flaky tests**: 2-4 hours per test → 15 minutes (AI diagnoses root cause)
+
+### Quality Improvements
+
+- **Coverage**: 70% → 90%+ (comprehensive generation catches gaps)
+- **Execution time**: 2 hours → 15 minutes (smart test selection via coverage)
+- **Maintenance burden**: 30% reduction (deduplication and standardization)
+- **Flakiness**: 20-30% reduction (systematic healing methodology)
+
+---
+
+## Recommended Workflows by Role
+
+### QA Engineer
+1. **Start**: `project-scan` → understand what exists
+2. **Create**: `generate-cases` → write new tests
+3. **Improve**: `improve-test-cases` → polish before upload
+4. **Upload**: `sync-cases` → push to Testomat.io
+5. **Automate**: `automate-test-cases` → create automation
+
+### QA Lead
+1. **Audit**: `project-scan` + `find-duplicate-cases` → assess quality
+2. **Plan**: `generate-cases` → create comprehensive test strategy
+3. **Organize**: `sync-cases` + `improve-test-cases` → standardize
+4. **Optimize**: `manual-coverage` + `automation-coverage` → smart execution
+5. **Monitor**: `reporter-setup` → centralized visibility
+
+### DevOps Engineer
+1. **Discover**: `project-scan` → identify frameworks
+2. **Integrate**: `reporter-setup` → add reporting to CI/CD
+3. **Optimize**: `automation-coverage` + `manual-coverage` → smart pipelines
+4. **Fix**: `automation-debug-tests` → stabilize failing tests
+
+### QA Manager
+1. **Assessment**: `project-scan` → current state
+2. **Planning**: `generate-cases` + `testomatio-flow` → strategy
+3. **Execution**: `reporter-setup` + `sync-cases` → infrastructure
+4. **Insight**: `manual-coverage` + `automation-coverage` → metrics
+5. **Improvement**: `find-duplicate-cases` → optimization opportunities
+
+---
+
+## Key Success Metrics
+
+### Efficiency Metrics
+- Time to generate test suite (target: 80% reduction)
+- Time to set up automation (target: 85% reduction)
+- Time to identify duplicates (target: 90% reduction)
+
+### Quality Metrics
+- Test case clarity score (target: 95%+)
+- Test execution success rate (target: 98%+)
+- Code coverage by tests (target: +20% improvement)
+
+### Team Metrics
+- Team satisfaction with test documentation (target: 90%+)
+- Time spent debugging vs. developing features (target: 20% → 5%)
+- New team member onboarding time (target: 3 days → 1 day)
+
+---
+
+## Integration Points
+
+### Pre-Integration Checklist
+- [ ] Testomat.io account and API key ready
+- [ ] Project repository structure understood
+- [ ] Testing framework identified
+- [ ] Team trained on basic skill usage
+
+### Post-Integration Wins
+- Test generation becomes fast and comprehensive
+- Manual tests are standardized and clean
+- Coverage is mapped and visible
+- CI/CD pipelines are optimized
+- Team has centralized test management
+
+---
+
+## Next Steps
+
+1. **Prioritize**: Which skills are most valuable for your team?
+2. **Pilot**: Start with 1-2 skills in a non-critical project
+3. **Train**: Team members learn through hands-on usage
+4. **Expand**: Gradually integrate more skills into workflows
+5. **Optimize**: Collect feedback and refine processes
+

--- a/QA_AUTOMATION_WIN_SCENARIOS.md
+++ b/QA_AUTOMATION_WIN_SCENARIOS.md
@@ -1,0 +1,446 @@
+# 5 Realistic QA Scenarios Where Automation Skills Are a Game-Changer
+
+---
+
+## Scenario 1: 🔥 The Flaky Test Hell
+
+### The Problem
+
+**Situation**: Your team has a 2-year-old automation suite with 150+ e2e tests. Tests are supposed to run in CI/CD, but developers have lost trust:
+- Tests pass locally but fail in CI ~30% of the time
+- Tests pass on Tuesday but fail on Wednesday with no code changes
+- Team has to re-run tests 3-4 times to get green
+- Developers ignore test failures ("It's just flaky, run it again")
+- QA spends 20+ hours per week fighting flaky tests
+
+**Root Causes**:
+- Timing issues (elements appear at different speeds)
+- Locators break with UI changes
+- Assertion logic is too strict
+- Race conditions in async operations
+- Environment differences (local vs CI)
+
+**Manual Approach**:
+- Spend 2-4 hours per test debugging
+- Try different waits and retries
+- Manually check DOM and network
+- Guess at fixes
+- Tests often remain flaky
+
+### Why Automation Skills Win
+
+```
+Skills Used:
+├─ automation-debug-tests (PRIMARY)
+└─ automation-debug-tests (repeatedly for each flaky test)
+
+Process:
+1. automation-debug-tests analyzes failure
+2. AI identifies root cause: "locator is too brittle"
+3. AI suggests fix: "Use data-testid instead of XPath"
+4. AI applies fix automatically
+5. AI re-runs test to verify stability
+6. If still failing, tries next root cause
+7. Repeats up to 3 times before asking for help
+
+Key Advantage: Systematic diagnosis instead of random guessing
+```
+
+### The Win
+
+| Metric | Before | After | Impact |
+|--------|--------|-------|--------|
+| **Time per flaky test** | 2-4 hours | 15-20 min | ⚡ 85% faster |
+| **% of tests fixed** | 60-70% | 90-95% | ✅ Much higher success rate |
+| **Manual debugging time/week** | 20+ hours | 2-3 hours | 💰 Free up 17 hours/week |
+| **Developer confidence** | Low 😞 | High 😊 | 🎯 Tests are trustworthy |
+| **Re-run requests** | 3-4 times | 1-2 times | ⏱️ Faster feedback |
+
+### Expected Outcome
+
+**Week 1**: Fix 20-30 flaky tests (5-10 hours of focused work)  
+**Week 2**: Fix remaining flaky tests (5-10 hours)  
+**Week 3+**: Maintain stability, rarely see flaky tests again  
+
+**Result**: Developers trust CI again. Tests become reliable. Team morale improves.
+
+---
+
+## Scenario 2: 📚 The Manual Test Debt Bomb
+
+### The Problem
+
+**Situation**: Your company has been doing mostly manual testing. You have 500+ manual test cases in markdown/spreadsheets:
+- Tests are poorly documented (ambiguous steps, unclear expected results)
+- Duplicates everywhere (same test written 3-4 different ways)
+- Format is inconsistent across teams
+- Migrating to Testomat.io soon but scared of the mess
+- Manual testing takes 8+ hours per release cycle
+
+**Current State**:
+- 40% of tests are duplicates or near-duplicates
+- QA engineers spend 30% of time interpreting tests
+- Tests can't be automated because they're too unclear
+- Compliance audit found 15% coverage gaps
+
+**Manual Approach**:
+- Manually read each test (1000+ hours)
+- Manually identify duplicates (400+ hours)
+- Manually rewrite each test (2000+ hours)
+- Total: 3400+ hours = ~2 people × 2 months
+
+### Why Automation Skills Win
+
+```
+Skills Used:
+├─ project-scan (understand structure)
+├─ find-duplicate-cases (identify duplicates)
+├─ improve-test-cases (standardize format)
+├─ sync-cases (upload to Testomat.io)
+└─ automate-test-cases (convert best ones to automation)
+
+Process:
+1. project-scan: 5 min → understand 500 tests
+2. find-duplicate-cases: 15 min → identify 200 duplicates
+3. improve-test-cases: 1 hour → standardize 300 remaining tests
+4. sync-cases: 5 min → upload to Testomat.io
+5. automate-test-cases: 2 hours → convert 10-15 key tests
+
+Total: 3.5 hours of AI work + 2-3 hours of human review
+```
+
+### The Win
+
+| Metric | Before | After | Impact |
+|--------|--------|-------|--------|
+| **Time to clean up** | 400+ hours | 6 hours | ⚡ 98% faster |
+| **Duplicate tests** | 200 (40%) | 0 | 🧹 Clean slate |
+| **Test clarity score** | 60% | 95% | ✨ Much clearer |
+| **Time per manual test** | 8 min | 3 min | ⏱️ 60% faster execution |
+| **Automation potential** | 10% | 60% | 🤖 Most can be automated |
+| **Ready for migration** | ❌ No | ✅ Yes | 🎯 Migration ready |
+
+### Expected Outcome
+
+**Day 1**: Find 200 duplicates (1 hour of work)  
+**Days 2-3**: Improve 300 tests (2-3 hours of AI work)  
+**Day 4**: Upload to Testomat.io (1 hour)  
+**Week 2**: Automate best tests (8-12 hours focused work)  
+
+**Result**: Clean, professional test suite. Ready for Testomat.io. Can automate faster.
+
+---
+
+## Scenario 3: ⚡ The Slow CI Pipeline
+
+### The Problem
+
+**Situation**: Your CI/CD pipeline has become a bottleneck:
+- Full e2e test suite takes 2+ hours to run
+- Developers wait for test results before merging
+- Every PR runs ALL 200 e2e tests, even if only API changed
+- Cost: $5,000/month in CI infrastructure
+- Developers frustrated: "I just changed a comment, why run all tests?"
+
+**Current Reality**:
+- PR merged at 5pm → feedback at 7pm
+- Developer has already left for the day
+- Bugs get discovered in staging, not caught by CI
+- QA manually decides which tests to run (inconsistent)
+
+**Manual Approach**:
+- Manually maintain a list of which tests to run
+- Constantly update as tests are added
+- Inconsistent results
+- Still runs too many tests (1+ hour)
+
+### Why Automation Skills Win
+
+```
+Skills Used:
+├─ automation-coverage (PRIMARY)
+└─ reporter with coverage filtering
+
+Process:
+1. automation-coverage: map all 200 tests to source code (30 min)
+2. Generate coverage.e2e.yml file
+3. Configure CI to use: reporter run --filter "coverage:diff=main"
+4. Now CI automatically:
+   - Detects what changed in PR
+   - Runs ONLY tests that exercise that code
+   - Ignores unrelated tests
+
+Example:
+├─ PR changes: src/checkout/*.ts
+├─ Coverage map says: tests T234, T567, T891 cover checkout
+├─ CI runs: only those 3 tests (5 min instead of 2 hours)
+└─ Feedback: 5 minutes instead of 2 hours!
+```
+
+### The Win
+
+| Metric | Before | After | Impact |
+|--------|--------|-------|--------|
+| **Test suite duration** | 2+ hours | 15-20 min | ⚡ 90% faster |
+| **Time to feedback** | 2 hours | 10-15 min | 🚀 Instant feedback |
+| **Tests per PR** | 200 | 5-15 | 📉 90% fewer |
+| **CI cost** | $5,000/month | $500/month | 💰 Save $4,500 |
+| **Developer wait time** | 120 min | 15 min | ⏱️ 87.5% less waiting |
+| **Feedback quality** | Generic | Focused | 🎯 More relevant |
+
+### Expected Outcome
+
+**Setup Time**: 2-3 hours (one-time)  
+**Per PR**: Instant 5-15 minute feedback instead of 2-hour wait  
+
+**Monthly Savings**:
+- Infrastructure: $4,500
+- Developer time: 100+ hours not waiting
+- Bug detection: 20-30% faster
+
+**Result**: Developers get instant feedback. Cost drops 90%. Bugs caught sooner.
+
+---
+
+## Scenario 4: 🏢 The Scale Problem
+
+### The Problem
+
+**Situation**: Your startup is growing. Test automation was great at 50 tests, but now it's chaotic:
+- 300+ tests across 3 different frameworks (Playwright, Jest, Pytest)
+- 3 different reporting tools (no centralized visibility)
+- New developers can't figure out how to write tests
+- Test maintenance is consuming more time than building features
+- Tests are breaking faster than you can fix them
+
+**Current State**:
+- 40% of CI time spent fixing broken tests
+- Takes 3 days to add a new test properly
+- No clear best practices
+- Tests built inconsistently
+- Coverage is unclear
+
+**Manual Approach**:
+- Senior QA tries to document best practices
+- Sits with each developer (8+ hours training)
+- Still inconsistent
+- Each framework handled differently
+
+### Why Automation Skills Win
+
+```
+Skills Used:
+├─ reporter-setup (standardize all reporting)
+├─ automate-test-cases (best practices built-in)
+├─ automation-coverage (standardize coverage)
+└─ automation-debug-tests (consistent debugging)
+
+Benefits:
+1. reporter-setup auto-configures each framework
+   → All results in one place (Testomat.io)
+   
+2. automate-test-cases includes best practices
+   → New developers write tests correctly immediately
+   
+3. automation-coverage forces mapping discipline
+   → Standardized thinking about coverage
+   
+4. automation-debug-tests shows right way to fix
+   → Consistent debugging methodology
+
+Result: Scaling doesn't create chaos
+```
+
+### The Win
+
+| Metric | Before | After | Impact |
+|--------|--------|-------|--------|
+| **Time to add new test** | 3 days | 3 hours | ⚡ 88% faster |
+| **Test quality consistency** | 40% | 90% | ✨ Much more consistent |
+| **Reporting tools** | 3 different | 1 (Testomat.io) | 🎯 Single source of truth |
+| **Time to fix broken test** | 2 hours | 15 min | ⚡ 87.5% faster |
+| **Training time per developer** | 8 hours | 1 hour | 📚 Onboard faster |
+| **Test maintenance burden** | 40% of time | 10% of time | 💰 3x more time for features |
+
+### Expected Outcome
+
+**Week 1**: Set up reporter-setup for all 3 frameworks (1-2 hours)  
+**Week 2**: Establish coverage mapping (2-3 hours)  
+**Week 3+**: Use automate-test-cases + automation-debug-tests consistently  
+
+**Result**: Automated testing stops being a bottleneck. Team scales without chaos.
+
+---
+
+## Scenario 5: 🚀 The Legacy Codebase Modernization
+
+### The Problem
+
+**Situation**: Your company has a 10-year-old codebase with ZERO automation:
+- Everything is manual testing
+- 3-4 day release cycles because QA needs 3 days to test manually
+- Senior developers leave because releases are painful
+- Can't do continuous deployment
+- Every release is high-stress ("Did we test everything?")
+
+**Current Reality**:
+- 600 manual test cases
+- Manual testing takes 16-20 hours per release
+- QA team of 4 is at capacity just testing releases
+- Bugs slip through (manual testing misses things)
+- No time to improve, just reactive firefighting
+
+**Manual Approach**:
+- Slowly hire more QA engineers (expensive, takes months)
+- Try to build automation from scratch (6-12 months, risky)
+- Both have high cost and long timeline
+
+### Why Automation Skills Win
+
+```
+Skills Used:
+├─ project-scan (understand codebase)
+├─ generate-cases (clarify existing manual tests)
+├─ improve-test-cases (standardize them)
+├─ automate-test-cases (convert to automation)
+├─ reporter-setup (set up reporting)
+└─ automation-debug-tests (fix issues)
+
+Phased Approach (NO need to hire):
+Phase 1 (Week 1): Generate clear test cases from manual tests
+Phase 2 (Week 2-3): Automate 50% of critical tests (50 tests)
+Phase 3 (Week 4-5): Automate another 25% (75 tests)
+Phase 4 (Week 6): Set up CI/CD with automation
+Phase 5 (Week 7): Automate remaining 25%
+
+Total: 7 weeks vs. 6-12 months
+
+Time Investment:
+- 4 QA engineers × 7 weeks = 28 person-weeks
+- vs. hiring 2 more engineers = 104+ person-weeks
+```
+
+### The Win
+
+| Metric | Before | After | Impact |
+|--------|--------|-------|--------|
+| **Release cycle** | 3-4 days | 1 day | ⚡ 75% faster |
+| **Manual testing time** | 20 hours | 1 hour (smoke) | 🤖 95% automation |
+| **Bugs in production** | 15-20/release | 2-3/release | 🛡️ 85% fewer |
+| **Cost to automate** | $300k (hiring) | $0 (use skills) | 💰 Save $300k |
+| **Time to automate** | 6-12 months | 7 weeks | ⏱️ 10x faster |
+| **QA team capacity** | 100% testing | 30% testing | 💼 Can improve testing |
+
+### Expected Outcome
+
+**Months 1-2**: 50% of tests automated  
+**Months 2-3**: 75% of tests automated  
+**Months 3-4**: 100% of tests automated + CI/CD setup  
+
+**Year 1 Impact**:
+- Release time: 3-4 days → 1 day (52 extra releases/year!)
+- Bugs in production: 20 → 3 per release (80% reduction)
+- QA team: Can focus on strategy, not firefighting
+- Cost: $0 extra spend vs. $300k hiring
+- Timeline: 7 weeks vs. 6-12 months
+
+**Result**: From waterfall to continuous deployment. Team happiness increases. Cost savings massive.
+
+---
+
+## Comparison: Why Automation Skills Win in All 5 Scenarios
+
+### Root Cause Addressed
+
+| Scenario | Problem | How Skills Help |
+|----------|---------|-----------------|
+| 1. Flaky Tests | No systematic debugging | automation-debug-tests provides systematic methodology |
+| 2. Manual Test Debt | No efficient cleanup | Find-dups + improve + sync automates the cleanup |
+| 3. Slow CI | No smart test selection | automation-coverage enables selective test runs |
+| 4. Scale Problem | No standardization | Skills include best practices + consistency |
+| 5. Legacy Modernization | No automation | automate-test-cases converts manual → automated |
+
+### Common Pattern: AI Does Tedious Work
+
+```
+Traditional Approach:
+├─ Identify problem (hours of analysis)
+├─ Plan solution (meetings, discussions)
+├─ Manual execution (weeks of work)
+└─ Hope it works
+
+With Automation Skills:
+├─ Identify problem (5-10 min)
+├─ Run skill (10-20 min)
+├─ Review AI output (15-30 min)
+├─ Approve & deploy (5 min)
+└─ Know it works (verified by AI)
+```
+
+### The Human Element
+
+**What AI Does Well**: 
+- Systematic analysis (finding duplicates, root causes)
+- Repetitive work (applying the same pattern 100x)
+- Pattern recognition (identifying flaky test types)
+- Compliance with standards
+
+**What Humans Do Well**:
+- Review and judgment ("Does this make sense?")
+- Tradeoff decisions ("What's most important?")
+- Risk assessment ("Will this break anything?")
+- Communication ("Let me explain why...")
+
+### Success Factors
+
+1. **Clear Problem**: Know what you're solving
+2. **Skill Alignment**: Match skill to problem
+3. **Human Review**: Don't blindly trust AI
+4. **Iterative**: First batch might be 80% right, refine from there
+5. **Commitment**: Use the results (don't generate and ignore)
+
+---
+
+## How to Identify Your Scenario
+
+```
+Ask yourself:
+
+□ Are tests flaky/failing randomly?
+  → Scenario 1: Use automation-debug-tests
+
+□ Do you have 200+ manual tests that are messy?
+  → Scenario 2: Use find-duplicate-cases + improve-test-cases
+
+□ Does full test suite take 30+ minutes to run?
+  → Scenario 3: Use automation-coverage for smart selection
+
+□ Are you growing and struggling with consistency?
+  → Scenario 4: Use reporter-setup + automate-test-cases
+
+□ Do you have zero automation and want to modernize?
+  → Scenario 5: Use project-scan + automate-test-cases
+
+If YES to any of these:
+→ Automation Skills are a GAME-CHANGER for you
+```
+
+---
+
+## The Bottom Line
+
+**Automation Skills solve the hardest QA problems:**
+- ✅ Fixing flaky tests (can't ignore, affects everyone)
+- ✅ Cleaning up test debt (invisible cost, slows everything)
+- ✅ Speeding up feedback loops (multiplies productivity)
+- ✅ Managing scale (hard problem that gets worse)
+- ✅ Modernizing legacy systems (massive undertaking)
+
+**Without Skills**: These are 2-12 month projects, expensive, risky  
+**With Skills**: These are 1-7 week projects, low-cost, proven approach
+
+**ROI Calculation**:
+- 1 QA engineer spending 1 month = $8,000
+- Time saved per scenario = $50,000-$500,000
+- **ROI: 600% to 6000%**
+

--- a/QA_WORKFLOWS.md
+++ b/QA_WORKFLOWS.md
@@ -1,0 +1,688 @@
+# QA Workflows Using Testomatio Skills
+
+A practical guide for QA engineers showing how to use skills in real testing scenarios.
+
+---
+
+## 1. 🚀 New Feature Testing Workflow
+
+**Scenario**: A new feature is being developed. You need to create comprehensive tests.
+
+### Workflow Steps
+
+```
+1. Understand Feature Requirements
+   └─ Get requirements doc, design mockup, user story
+
+2. Generate Test Cases
+   └─ Use: generate-cases skill
+      • Input: Requirements/design
+      • Output: Checklist + detailed test cases
+      • Time: 15-20 min (vs. 4-6 hours manual)
+
+3. Review & Refine Tests
+   └─ Improve: improve-test-cases skill
+      • Input: Generated test cases
+      • Output: Polished, standardized tests
+      • Time: 10-15 min
+
+4. Upload to Testomat.io
+   └─ Use: sync-cases skill
+      • Input: Markdown test files
+      • Output: Tests in TMS
+      • Time: 2-3 min
+
+5. Set Up Automation
+   └─ Use: automate-test-cases skill
+      • Input: Test cases
+      • Output: Automated test scripts
+      • Time: 30-45 min per test
+
+6. Configure Reporting
+   └─ Use: reporter-setup skill
+      • Input: Project framework info
+      • Output: Reporting configured
+      • Time: 10-15 min (one-time)
+
+Total Time: ~2-3 hours (vs. 3-4 days manual)
+```
+
+### Output
+✅ Comprehensive test cases in Testomat.io  
+✅ Automated tests running in CI/CD  
+✅ Test results visible to the team  
+
+---
+
+## 2. 🔄 Bulk Test Improvement Workflow
+
+**Scenario**: You have 100+ legacy test cases that are poorly documented and inconsistent.
+
+### Workflow Steps
+
+```
+1. Assess Current State
+   └─ Use: project-scan skill
+      • Identify all test files
+      • Count manual tests
+      • Time: 5 min
+
+2. Find Duplicates
+   └─ Use: find-duplicate-cases skill
+      • Identify redundant tests
+      • Get merge recommendations
+      • Time: 10-15 min
+
+3. Remove/Merge Duplicates
+   └─ Manual action
+      • Execute recommendations
+      • Time: 1-2 hours (saved 8+ hours of analysis)
+
+4. Improve Remaining Tests
+   └─ Use: improve-test-cases skill
+      • Standardize format
+      • Clarify ambiguous steps
+      • Fix markdown issues
+      • Time: 20-30 min (vs. 2-3 days)
+
+5. Upload to Testomat.io
+   └─ Use: sync-cases skill
+      • Push improved tests
+      • Time: 3-5 min
+
+Total Time: ~3-4 hours (vs. 3-4 weeks manual)
+```
+
+### Output
+✅ Clean, standardized test suite  
+✅ 20-30% fewer redundant tests  
+✅ Tests ready for automation or TMS  
+
+---
+
+## 3. 🎯 Quick Feature Test Checklist Workflow
+
+**Scenario**: Friday before release - need a quick test checklist for a small feature.
+
+### Workflow Steps
+
+```
+1. Quick Checklist Generation
+   └─ Use: generate-cases skill
+      • Input: Simple feature description
+      • Coverage: "Smoke" (minimal)
+      • Output: Quick checklist (5-10 items)
+      • Time: 2-5 min
+
+2. Execute Tests Manually
+   └─ Go test the feature
+      • Use checklist as guide
+      • Time: 10-30 min
+
+3. Optional: Expand Coverage
+   └─ Use: generate-cases skill again
+      • Coverage: "Balanced" or "Exhaustive"
+      • Get more edge cases
+      • Time: 5-10 min
+
+Total Time: ~20-40 min (vs. 1-2 hours planning manually)
+```
+
+### Output
+✅ Quick, structured testing  
+✅ Comprehensive coverage with minimal effort  
+✅ Clear test documentation  
+
+---
+
+## 4. 🏗️ Full Test Automation Setup Workflow
+
+**Scenario**: Starting test automation from scratch for a mature project.
+
+### Workflow Steps
+
+```
+1. Scan Project
+   └─ Use: project-scan skill
+      • Detect framework (Playwright, Jest, etc.)
+      • Identify existing tests
+      • Time: 5 min
+
+2. Set Up Reporting
+   └─ Use: reporter-setup skill
+      • Auto-detect framework
+      • Install reporter package
+      • Configure reporting
+      • Time: 10-15 min (vs. 4-8 hours manual)
+
+3. Pull Existing Manual Tests
+   └─ Use: sync-cases skill
+      • Pull from Testomat.io
+      • Time: 2-3 min
+
+4. Automate Key Flows
+   └─ Use: automate-test-cases skill
+      • Convert manual → automated
+      • Run & verify
+      • Time: 30-45 min per test
+
+5. Create Coverage Maps
+   └─ Use: automation-coverage skill
+      • Map tests to source code
+      • Generate coverage.e2e.yml
+      • Time: 15-20 min
+
+6. Verify Setup
+   └─ Run tests locally and in CI
+      • Time: 10-15 min
+
+Total Time: ~3-4 hours (vs. 2-3 days manual setup)
+```
+
+### Output
+✅ Automated tests in CI/CD  
+✅ Reporting configured and working  
+✅ Coverage mappings for smart test selection  
+
+---
+
+## 5. 🐛 Fix Failing Test Workflow
+
+**Scenario**: A test passed locally but fails in CI. Need to fix it fast.
+
+### Workflow Steps
+
+```
+1. Diagnose Failure
+   └─ Use: automation-debug-tests skill
+      • Analyze error type
+      • Check DOM, logs, screenshots
+      • Identify root cause
+      • Time: 5-10 min (vs. 30+ min manual)
+
+2. Apply Fix
+   └─ automation-debug-tests continues
+      • Update locators / timing / assertions
+      • Auto-heals up to 3 times
+      • Time: 5-10 min
+
+3. Verify Fix
+   └─ Re-run test
+      • Check it passes consistently
+      • Time: 2-3 min
+
+4. Document
+   └─ Understand what broke and why
+      • Time: 2-3 min
+
+Total Time: ~15-20 min (vs. 2-4 hours manual)
+```
+
+### Output
+✅ Fixed, stable test  
+✅ Understanding of root cause  
+✅ Confidence in CI/CD  
+
+---
+
+## 6. 📊 Smart Regression Testing Workflow
+
+**Scenario**: PR changes only checkout flow. Don't want to run full 2-hour test suite.
+
+### Workflow Steps
+
+```
+1. Setup Coverage Maps (one-time)
+   └─ Use: manual-coverage skill
+      • Map manual tests to code
+      • Generate coverage.manual.yml
+      • Time: 20-30 min (one-time setup)
+
+2. Generate E2E Coverage (one-time)
+   └─ Use: automation-coverage skill
+      • Map e2e tests to code
+      • Generate coverage.e2e.yml
+      • Time: 20-30 min (one-time setup)
+
+3. Run Smart Regression
+   └─ For any PR:
+      • Run: npx reporter run --filter "coverage:file=coverage.e2e.yml,diff=main"
+      • Automatically runs only affected tests
+      • Time: 5-15 min (vs. 2 hours)
+
+Per PR Time: ~10 min (vs. 2+ hours)
+```
+
+### Output
+✅ Only relevant tests run  
+✅ 10-15x faster feedback  
+✅ Lower CI cost  
+✅ Developers get instant feedback  
+
+---
+
+## 7. 🔗 Map Tests to Requirements Workflow
+
+**Scenario**: You need to show which tests cover which requirements.
+
+### Workflow Steps
+
+```
+1. Scan Project
+   └─ Use: project-scan skill
+      • Understand test structure
+      • Time: 5 min
+
+2. Create Manual Coverage Map
+   └─ Use: manual-coverage skill
+      • Analyze test steps
+      • Map to source code areas
+      • Generate coverage.manual.yml
+      • Time: 20-30 min
+
+3. Create Automation Coverage Map
+   └─ Use: automation-coverage skill
+      • Analyze e2e tests
+      • Map to code areas
+      • Generate coverage.e2e.yml
+      • Time: 20-30 min
+
+4. Create Traceability Report
+   └─ Manual or tool-based
+      • Show requirements → tests mapping
+      • Identify coverage gaps
+      • Time: 30-45 min
+
+Total Time: ~2 hours (vs. 1-2 days manual analysis)
+```
+
+### Output
+✅ Traceability matrix  
+✅ Clear coverage visibility  
+✅ Gap analysis  
+✅ Compliance documentation  
+
+---
+
+## 8. 🎭 Multi-Role Test Coverage Workflow
+
+**Scenario**: Need different test scenarios for different user perspectives.
+
+### Workflow Steps
+
+```
+1. Generate Default Tests
+   └─ Use: generate-cases skill
+      • Select role: Default (⚙️)
+      • Generate happy path tests
+      • Time: 15-20 min
+
+2. Generate Pessimist Tests
+   └─ Use: generate-cases skill again
+      • Select role: Pessimist (😈)
+      • Generate error scenarios
+      • Time: 15-20 min
+
+3. Generate User-Centric Tests
+   └─ Use: generate-cases skill again
+      • Select role: User (🎭)
+      • Generate real user workflows
+      • Time: 15-20 min
+
+4. Combine & Upload
+   └─ Use: improve-test-cases + sync-cases
+      • Consolidate all tests
+      • Remove actual duplicates
+      • Upload to Testomat.io
+      • Time: 20-30 min
+
+Total Time: ~1.5-2 hours (vs. 1-2 days with different perspectives)
+```
+
+### Output
+✅ Comprehensive test coverage  
+✅ Multiple perspectives covered  
+✅ Happy path + edge cases + user scenarios  
+
+---
+
+## 9. 📱 Prepare Tests for Automation Workflow
+
+**Scenario**: Manual test suite is ready, now convert to automation.
+
+### Workflow Steps
+
+```
+1. Audit Existing Tests
+   └─ Use: find-duplicate-cases skill
+      • Find duplicates before automating
+      • Remove redundant tests
+      • Time: 10-15 min (saves 10+ hours later)
+
+2. Improve Test Quality
+   └─ Use: improve-test-cases skill
+      • Clarify ambiguous steps
+      • Standardize format
+      • Time: 20-30 min
+
+3. Automate Core Flows
+   └─ Use: automate-test-cases skill
+      • Prioritize: critical + frequently-used tests
+      • Convert to automation
+      • Time: 30-45 min per test
+
+4. Debug & Stabilize
+   └─ Use: automation-debug-tests skill
+      • Fix any failures
+      • Stabilize flaky tests
+      • Time: 5-10 min per test
+
+Total Time: ~3-4 hours for 5-6 tests (vs. 1-2 days)
+```
+
+### Output
+✅ Stable, maintainable automated tests  
+✅ No wasted effort on duplicate automation  
+✅ High quality before automation  
+
+---
+
+## 10. 🔍 Pre-Release Quality Check Workflow
+
+**Scenario**: Before release, ensure test coverage and quality is good.
+
+### Workflow Steps
+
+```
+1. Scan for Framework & Tests
+   └─ Use: project-scan skill
+      • See what exists
+      • Identify gaps
+      • Time: 5 min
+
+2. Find Duplicates
+   └─ Use: find-duplicate-cases skill
+      • Identify redundancy
+      • Get cleanup recommendations
+      • Time: 10-15 min
+
+3. Analyze Coverage
+   └─ Use: manual-coverage + automation-coverage skills
+      • Map tests to code
+      • Identify untested areas
+      • Time: 30-40 min
+
+4. Create Report
+   └─ Manual:
+      • Summary: Total tests, coverage %, gaps
+      • Recommendations for coverage improvements
+      • Time: 15-20 min
+
+5. Fix Critical Gaps
+   └─ Use: generate-cases skill
+      • Generate tests for uncovered areas
+      • Time: 20-30 min
+
+Total Time: ~1.5-2 hours (vs. 1-2 days manual audit)
+```
+
+### Output
+✅ Pre-release quality assessment  
+✅ Coverage report  
+✅ Risk areas identified  
+✅ Ready-to-merge confidence  
+
+---
+
+## 11. 👥 Onboard New QA Team Member Workflow
+
+**Scenario**: New QA engineer joining team. Need to get them up to speed.
+
+### Workflow Steps
+
+```
+Day 1: Understanding the Project
+
+1. Scan Project
+   └─ Use: project-scan skill
+      • Show all languages, frameworks, tests
+      • Time: 5 min
+      • Output: "Here's what exists"
+
+2. Find Duplicates (informational)
+   └─ Use: find-duplicate-cases skill
+      • Explain code organization
+      • Time: 10-15 min
+      • Output: "This is our test landscape"
+
+Day 2-3: Create Tests
+
+3. Generate Sample Test Cases
+   └─ Use: generate-cases skill
+      • Generate tests for a small feature
+      • Learn the skill
+      • Time: 20-30 min
+
+4. Improve Tests
+   └─ Use: improve-test-cases skill
+      • See best practices applied
+      • Time: 10-15 min
+
+5. Upload to TMS
+   └─ Use: sync-cases skill
+      • See workflow end-to-end
+      • Time: 5 min
+
+Day 4-5: Automation Basics
+
+6. Set Up Reporting
+   └─ Use: reporter-setup skill
+      • See automation infrastructure
+      • Time: 10-15 min
+
+7. Automate a Test
+   └─ Use: automate-test-cases skill
+      • Hands-on automation
+      • Time: 30-45 min
+
+8. Fix a Failing Test
+   └─ Use: automation-debug-tests skill
+      • Debugging skills
+      • Time: 15-20 min
+
+Total Time: ~3-4 hours training + 2-3 hours hands-on
+```
+
+### Output
+✅ New team member comfortable with skills  
+✅ Understands testing landscape  
+✅ Can generate, improve, and automate tests  
+✅ Ready to contribute independently  
+
+---
+
+## 12. 📈 Continuous Improvement Workflow
+
+**Scenario**: Recurring process to keep test suite healthy.
+
+### Workflow Steps (Monthly)
+
+```
+Week 1: Assessment
+
+1. Scan Project
+   └─ Use: project-scan skill
+      • Check test count trends
+      • Time: 5 min
+
+2. Find Duplicates
+   └─ Use: find-duplicate-cases skill
+      • Identify new duplicates
+      • Time: 10-15 min
+
+Week 2: Cleanup
+
+3. Remove Duplicates
+   └─ Manual execution of recommendations
+      • Time: 30-60 min
+
+4. Improve Quality
+   └─ Use: improve-test-cases skill
+      • Address new quality issues
+      • Time: 15-20 min
+
+Week 3: Coverage Analysis
+
+5. Update Coverage Maps
+   └─ Use: manual-coverage + automation-coverage skills
+      • Refresh code-to-test mappings
+      • Time: 20-30 min
+
+Week 4: Reporting & Planning
+
+6. Generate Report
+   └─ Manual:
+      • Test metrics
+      • Coverage trends
+      • Improvement recommendations
+      • Time: 15-20 min
+
+Total Monthly Time: ~2-3 hours (automated, repeatable)
+```
+
+### Output
+✅ Healthy, efficient test suite  
+✅ Continuous quality improvement  
+✅ Metrics tracking  
+✅ Data-driven decisions  
+
+---
+
+## Quick Reference: Skill Use Cases by Frequency
+
+### Daily Use
+- **automation-debug-tests**: When tests fail in CI/CD
+- **project-scan**: When exploring unfamiliar code
+
+### Weekly Use
+- **generate-cases**: Creating tests for new features
+- **improve-test-cases**: Polishing test documentation
+- **automate-test-cases**: Converting manual to automated
+
+### Monthly Use
+- **find-duplicate-cases**: Quality audit
+- **manual-coverage**: Coverage analysis
+- **automation-coverage**: Coverage optimization
+
+### Setup (One-time)
+- **reporter-setup**: Initial project configuration
+- **sync-cases**: First sync to Testomat.io
+- **testomatio-flow**: Planning testing strategy
+
+---
+
+## Time Savings Summary
+
+| Workflow | Manual Time | With Skills | Savings |
+|----------|------------|-------------|---------|
+| New feature testing | 3-4 days | 2-3 hours | **90%** |
+| Bulk test improvement | 3-4 weeks | 3-4 hours | **95%** |
+| Test automation setup | 2-3 days | 3-4 hours | **80%** |
+| Fix failing test | 2-4 hours | 15-20 min | **85%** |
+| Smart regression | 2 hours per PR | 10 min | **90%** |
+| Coverage analysis | 1-2 days | 1-2 hours | **85%** |
+
+---
+
+## Pro Tips for QA Engineers
+
+### 1. **Always Start with project-scan**
+   - Understand what exists first
+   - Identify frameworks and current tests
+   - Avoid duplicating work
+
+### 2. **Find Duplicates Before Improving**
+   - Run find-duplicate-cases before improve-test-cases
+   - Save effort improving tests you'll delete anyway
+
+### 3. **Leverage Coverage Maps**
+   - Set up once, use forever
+   - Makes PR testing 10x faster
+
+### 4. **Use Smoke Tests for Quick Checks**
+   - generate-cases with "Smoke" coverage for Friday afternoon testing
+   - 2-5 minute quick checklist
+
+### 5. **Combine Skills for Maximum Efficiency**
+   - generate → improve → sync → automate is a powerful pipeline
+   - Use testomatio-flow to guide the process
+
+### 6. **Automate Debugging**
+   - Don't manually debug failing tests
+   - Let automation-debug-tests do the analysis
+   - You review and approve the fix
+
+### 7. **Keep Testomat.io in Sync**
+   - Use sync-cases regularly
+   - Pull, edit, push workflow is powerful
+   - TMS becomes source of truth
+
+### 8. **Review AI Output, Don't Trust Blindly**
+   - Skills are 90%+ accurate
+   - Always review generated tests
+   - Flag edge cases the AI might have missed
+
+---
+
+## Workflow Decision Tree
+
+```
+What do you need to do?
+
+├─ Create new tests?
+│  └─ Use: generate-cases
+│     └─ Then: improve-test-cases → sync-cases
+│
+├─ Improve existing tests?
+│  └─ Use: find-duplicate-cases first
+│     └─ Then: improve-test-cases → sync-cases
+│
+├─ Automate tests?
+│  └─ Use: automate-test-cases
+│     └─ If fails: automation-debug-tests
+│
+├─ Fix failing test?
+│  └─ Use: automation-debug-tests
+│
+├─ Understand project?
+│  └─ Use: project-scan
+│
+├─ Optimize test execution?
+│  └─ Use: manual-coverage + automation-coverage
+│
+├─ Set up reporting?
+│  └─ Use: reporter-setup (one-time)
+│
+└─ Manage complete lifecycle?
+   └─ Use: testomatio-flow
+```
+
+---
+
+## Common Questions
+
+**Q: When should I use generate-cases vs. testomatio-flow?**
+A: Use generate-cases for focused test creation. Use testomatio-flow when you need end-to-end guidance through the entire testing workflow.
+
+**Q: How often should I run find-duplicate-cases?**
+A: Monthly during continuous improvement, or before major refactoring. Also before migrating to new TMS.
+
+**Q: Do I need to set up coverage maps?**
+A: Only if you want smart test selection and faster CI/CD. One-time setup, huge payoff for large test suites.
+
+**Q: Can I use these skills for API testing?**
+A: Most skills work for manual tests. For automation, focus on framework support (Playwright, CodeceptJS, Jest, Pytest, etc.).
+
+**Q: What if a skill makes a mistake?**
+A: Review output before committing. Skills are ~90% accurate. Flag issues for improvement and manually fix critical items.
+

--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@ For other ways of installation (Claude Code plugin, Codex, Cursor etc.) see [ins
 
 | Skill                  | Description                                                                                          |
 | ---------------------- | ---------------------------------------------------------------------------------------------------- |
+| `qa-explain-behavior`  | Answer QA questions about product behavior — features, flows, rules, edge cases, and what is not implemented |
 | `qa-write-test-cases`       | Generate test cases and checklists from requirements, tickets, or feature descriptions               |
 | `qa-thinking`          | Analyze a feature from a QA perspective — edge cases, negative flows, abuses, unobvious scenarios |
 | `qa-split-testing-levels-pyramid` | Apply the test pyramid to a feature — assign scenarios to testing levels, coverage split per level |
@@ -110,7 +111,7 @@ Skills are also bundled as [Claude Code plugins](https://docs.testomat.io) via t
 
 | Plugin            | Bundled skills                                                       | Use it to                                                                       |
 | ----------------- | ------------------------------------------------------------------- | ------------------------------------------------------------------------------ |
-| `qa-process`      | `qa-lead-strategy-advisor`, `qa-thinking`, `testing-workflow`        | Assess QA maturity, prioritize a quality roadmap, and orchestrate the test lifecycle |
+| `qa-process`      | `qa-lead-strategy-advisor`, `qa-explain-behavior`, `qa-thinking`, `testing-workflow` | Assess QA maturity, prioritize a quality roadmap, explain product behavior, and orchestrate the test lifecycle |
 | `test-management` | `qa-write-test-cases`, `improve-test-cases`, `sync-test-cases-with-tms`, coverage & more | Manage the test case lifecycle: generate, improve, sync to Testomat.io          |
 | `test-automation` | `automate-manual-test-cases`, `debug-fix-failed-flaky-autotests`, `qa-data-seeder` | Create automated tests, heal failing/flaky autotests, and seed test data        |
 | `explorbot`       | `explorbot-setup`, `explorbot-fundamentals`, `explorbot-plan`        | Install, configure, run, debug and plan Explorbot autonomous AI web tests       |

--- a/plugins/qa-process/skills/qa-explain-behavior
+++ b/plugins/qa-process/skills/qa-explain-behavior
@@ -1,0 +1,1 @@
+../../../skills/qa-explain-behavior

--- a/skills/qa-explain-behavior/SKILL.md
+++ b/skills/qa-explain-behavior/SKILL.md
@@ -1,0 +1,111 @@
+---
+name: qa-explain-behavior
+description: Answers QA questions about product behavior — what features exist, how user flows work, what business rules apply, what edge cases the system handles, and what is or is not implemented. Use whenever the user asks a question about WHAT the system does (features, flows, rules, conditions, who-can-do-what, when-does-X-happen, is-Y-supported). Trigger even when the user does not say "QA" — phrases like "what happens when…", "can a user…", "is it possible to…", "does the system…", "is X implemented", "what should I test for…", "what are the edge cases of…", or "walk me through the flow for…" all qualify. Do NOT trigger for questions that are clearly about implementation (architecture, database schema, code structure, performance, types, dependencies).
+license: MIT
+metadata:
+  author: Testomat.io
+  version: 1.0.0
+---
+
+# QA Explain Behavior
+
+Answer a QA engineer who is testing the product. They care about **product behavior**, not implementation. Read the codebase like a manual and translate it into plain-language descriptions of what the system does.
+
+| What | File |
+|------|------|
+| Output shape per question type — feature, flow, yes/no, permissions, edge cases | [references/answer-shapes.md](references/answer-shapes.md) |
+| Worked answers, plus bad-vs-good contrasts | [references/examples.md](references/examples.md) |
+
+## The mindset shift
+
+The QA engineer is not going to read the code. They are going to click buttons, fill forms, and try to break things. The answer should help them know what to click, what to expect, and where the product might fail. Describe the product like someone who has used it end-to-end.
+
+A QA engineer's mental model is built from:
+
+- **Actors** — who is doing this: guest, member, admin, owner, integration.
+- **Actions** — what they do: click, submit, upload, invite.
+- **Outcomes** — what they see or what changes: page, message, email, status.
+- **Rules** — when it's allowed, when it's blocked, what limits apply.
+- **Edge cases** — empty state, very large input, duplicate, expired, offline.
+
+Frame every answer in those terms.
+
+## What to investigate
+
+Look at the parts of the codebase that **describe behavior**, not the parts that describe data:
+
+- **Service and controller layers** — what user actions exist, and the multi-step flows behind them.
+- **Business logic** — the rules that decide what is allowed, what changes, and what happens next.
+- **Authorization and permissions system** — who can do what, and whether the block is in the UI, on the server, or both.
+- **Feature flags** — what is switched on, off, or limited to certain accounts.
+- **Configuration** — limits, defaults, and behavior that differs per environment or plan.
+- **Models** — only *validations*, *state machines*, *callbacks*, and *scopes with business meaning*. Not columns, associations, or types.
+- **Views, serializers, mailers** — what the user sees and receives.
+- **Background jobs** — what happens after the user-visible action: notifications, syncs, cleanups.
+- **Tests** — they describe expected behavior in plain English; very useful.
+
+## What to ignore
+
+Unless the user explicitly asks, never mention:
+
+- Database tables, columns, indexes, schema.
+- Class names, file paths, line numbers, module structure.
+- Framework terminology and internals — ORM concepts, callbacks, middleware, queues, dependencies.
+- Variable names, method names, parameters, types.
+- SQL, code snippets, regex.
+- Performance, scaling, architecture decisions.
+- Migration history, refactors.
+
+If the user wants this, they will ask. The default is product-level only.
+
+## How to answer
+
+**Be compact.** A QA engineer scans, they don't read paragraphs. Short bullets, short sentences, plain words.
+
+**Lead with the answer.** No preamble, no restating the question, no "Let me explain…".
+
+**Use product vocabulary, not code vocabulary:**
+
+- "the user", "the admin", "the workspace owner" — not `current_user`.
+- "the settings page" — not a controller action name.
+- "an email is sent" — not a mailer class.
+- "it's blocked" — not "validation fails".
+- "in the background" — not the name of the queue.
+
+**Structure by what a tester needs.** When describing a feature, default to this shape:
+
+```
+**What it does:** one line
+**Who can do it:** roles / permissions
+**How to trigger it:** user action(s)
+**What happens:** outcomes (UI, emails, notifications, status changes)
+**Rules / limits:** validations, conditions
+**Edge cases:** empty, duplicate, large, expired, blocked, etc.
+**Not implemented:** anything the QA might expect that does NOT exist
+```
+
+For flow questions, describe the flow as numbered steps from the user's point of view. For "is X supported?" questions, answer **yes** or **no** first, then a one-line reason, then any nuance. Permission questions, edge-case sweeps, failure behavior, comparisons, and how to phrase uncertainty each have their own shape in [references/answer-shapes.md](references/answer-shapes.md).
+
+**Surface what is missing.** The most valuable thing a QA engineer can hear is "this is not implemented", "there is no UI for this — only the API supports it", or "this only works for paying accounts". Always look for gaps and call them out: a flag, a TODO, a commented-out path, an action reachable only via API.
+
+**Be honest about uncertainty.** If the codebase is ambiguous, say "I see X but I'm not sure whether Y" rather than guessing. A QA testing on a wrong assumption is worse than a QA who knows to verify.
+
+## Do not write code
+
+Never produce code blocks, schema, configuration snippets, or pseudocode unless the user explicitly asks ("show me the code", "give me the SQL"). The default response is prose and bullets only. When tempted to paste code "to be helpful", describe the behavior instead.
+
+When the product **is** a CLI or an API, the commands, flags, and endpoints a user types are product surface, not implementation — name them exactly, the same way you would name a button.
+
+[references/examples.md](references/examples.md) has worked answers — a full feature description, a flow walkthrough, an edge-case sweep — and two bad-vs-good contrasts showing what code leaking into an answer looks like.
+
+## Next actions
+
+Offer after the answer:
+
+- Turn the behavior into risk scenarios → `qa-thinking` skill.
+- Turn it into test cases or a checklist → `qa-write-test-cases` skill.
+- Map which tests already cover it → `qa-test-code-coverage` skill.
+
+## Final reminder
+
+Compact. Plain language. Behavior, not code. Highlight gaps. No code unless asked.

--- a/skills/qa-explain-behavior/references/answer-shapes.md
+++ b/skills/qa-explain-behavior/references/answer-shapes.md
@@ -1,0 +1,116 @@
+# Answer shapes
+
+Pick the shape that matches the question. Skip any section that doesn't apply —
+never pad with "N/A" or "None". Bullets over paragraphs, short lines, plain
+words.
+
+## Feature description — "what does X do", "explain X"
+
+The default shape. Most questions land here.
+
+```
+**What it does:** one line
+**Who can do it:** roles / permissions
+**How to trigger it:** the clicks, in order
+**What happens:** outcomes — screen, message, email, status change, background work
+**Rules / limits:** validations, conditions, plan gating
+**Edge cases:** empty, duplicate, too large, expired, blocked, concurrent
+**Not implemented:** anything a tester would reasonably expect that doesn't exist
+```
+
+## Flow walkthrough — "walk me through…", "how does someone…"
+
+Numbered steps from the user's point of view, one screen per step. Say where
+the flow can branch or die.
+
+```
+1. User clicks **X** on the … page.
+2. …
+3. …
+
+**Branches:**
+- If <condition>, they land on … instead.
+- If <condition>, it stops with "<the actual message>".
+
+**After it finishes:** <emails, notifications, anything delayed>
+```
+
+## Yes / no — "is X supported", "can I…", "is there a way to…"
+
+Answer in the first word. Then one line of why. Then nuance, if any.
+
+```
+Yes — partially.
+- <what works, and where>
+- <what doesn't>
+- <what exists in the API but has no UI>
+```
+
+If it's a flat no, one or two lines is the whole answer. Don't inflate it.
+
+## Permissions — "can a *role* do X", "who can…"
+
+Say whether the block is in the UI, on the server, or both — a tester needs to
+know if they can get past it by calling the API directly.
+
+```
+No. Guests can view … but cannot …
+The button is hidden for guests, and the action is blocked server-side too.
+```
+
+For several roles at once, use a small table:
+
+```
+| Role | Create | Edit | Delete |
+|---|---|---|---|
+| Owner | ✅ | ✅ | ✅ |
+| Member | ✅ | ✅ | ❌ |
+| Guest | ❌ | ❌ | ❌ |
+```
+
+## Edge cases — "what could go wrong", "what should I test"
+
+Group by the kind of input or state, so the list is walkable as a test session.
+Each line is a condition plus what actually happens.
+
+```
+**Empty / missing:** …
+**Duplicate:** …
+**Too large / too many:** …
+**Wrong format:** …
+**Expired / stale:** …
+**Permissions:** …
+**Concurrent:** two people doing this at once …
+**External failure:** the integration is down / the upload fails …
+```
+
+## Failure behaviour — "what happens if it fails"
+
+Testers need the observable result, not the exception.
+
+```
+**What the user sees:** the actual message or screen
+**What state it's left in:** saved / not saved / half-saved
+**Whether it retries:** automatically, manually, or not at all
+```
+
+## Comparison — "what's the difference between X and Y"
+
+Two columns, same rows. Only rows where they actually differ.
+
+## Phrasing uncertainty
+
+Never guess silently. Use the shape "I can see X, but I couldn't confirm Y":
+
+- "The API accepts this, but I couldn't find a UI that reaches it."
+- "There's a limit of 100 here, but I'm not sure whether it's enforced on
+  import as well — worth verifying."
+- "This looks gated by a feature flag. Whether it's on for your account, I
+  can't tell from the code."
+
+## Length
+
+Match the question. A yes/no question gets two lines. A "walk me through the
+whole import flow" gets a full shape. If your answer runs past about a screen,
+either the question was broad or you're explaining implementation — check
+which.

--- a/skills/qa-explain-behavior/references/examples.md
+++ b/skills/qa-explain-behavior/references/examples.md
@@ -1,0 +1,157 @@
+# Worked examples
+
+> The product below is **invented** — a generic workspace app with members,
+> documents and file imports. These examples show the shape and register of a
+> good answer, not real behaviour. Always answer from what you actually find in
+> the codebase in front of you.
+
+## Example 1 — feature description
+
+**Q: "What happens when a user is invited to a workspace?"**
+
+```
+**What it does:** sends an invitation so someone can join a workspace with a chosen role.
+**Who can do it:** workspace owner and admins.
+**How to trigger:** Workspace Settings → Members → "Invite" → enter email + pick role.
+**What happens:**
+- Invitation email is sent to that address.
+- Pending invite shows in the members list.
+- If the email matches an existing user, they accept by clicking the link and the workspace appears in their sidebar.
+- If not, they're prompted to register first; after register they land on the workspace.
+**Rules:**
+- Email must be valid.
+- Same email can't have two pending invites for the same workspace.
+- Role must be one of: owner, admin, member, guest.
+**Edge cases:**
+- Invite link expires after 7 days.
+- If the invited user is already a member, the invite is rejected with a message.
+- Re-sending an invite resets the expiry.
+**Not implemented:** bulk invite via CSV is not available in the UI.
+```
+
+Why it works: every line is something a tester can act on. The last line is the
+most valuable one in the answer.
+
+## Example 2 — permission question
+
+**Q: "Can a guest delete a document?"**
+
+```
+No. Guests can view documents but cannot edit, create, or delete them. The
+delete button is hidden for guests, and the action is also blocked server-side.
+```
+
+Two lines, and it answers the follow-up question a tester was about to ask —
+whether the block survives a direct API call.
+
+## Example 3 — support question with nuance
+
+**Q: "Is there a way to export a document?"**
+
+```
+Yes — partially.
+- CSV export is available from the document page (top-right menu).
+- PDF export is **not** implemented.
+- The raw JSON can be retrieved via API, but there's no UI button for it.
+```
+
+"Yes — partially" in the first line, then exactly where the line falls.
+
+## Example 4 — flow walkthrough
+
+**Q: "Walk me through importing records from a file."**
+
+```
+1. Workspace → Data → "Import" → pick a file (CSV or XLSX).
+2. A preview shows the first rows with a column-mapping step — you map each
+   column to a field (name, owner, category, tags).
+3. Confirm. The import runs in the background; the page shows a progress state.
+4. When it finishes you get an in-app notification with a summary: created,
+   updated, skipped.
+
+**Branches:**
+- If a row has no name, it's skipped and counted in "skipped".
+- If a record with the same name already exists in that category, it's updated
+  rather than duplicated.
+- If the whole file can't be parsed, nothing is imported and you get an error
+  on the same screen.
+
+**Rules / limits:**
+- File must be under 10 MB.
+- Only CSV and XLSX; other extensions are rejected before upload.
+
+**Edge cases:**
+- An empty file imports nothing and reports "0 created".
+- Closing the tab doesn't cancel the import — it keeps running.
+
+**Not implemented:** there's no way to undo or roll back an import.
+```
+
+## Example 5 — edge-case sweep
+
+**Q: "What should I test around document deletion?"**
+
+```
+**Permissions:** owner and admin can delete; member and guest cannot (hidden and blocked server-side).
+**Empty:** deleting a document with no content works and removes it immediately.
+**In use:** a document open in someone else's tab can be deleted — their next save fails with a generic error, which is worth checking.
+**Linked data:** attached files are removed in the background, so they can outlive the document by a few seconds.
+**Concurrent:** two admins deleting the same document at once — the second gets a "not found" error rather than a friendly message.
+**Undo:** there is none, and there's no confirmation step on the API — only in the UI.
+```
+
+## Contrast — the same question answered badly
+
+**Q: "What happens when an import finishes?"**
+
+❌ **Bad — implementation leaking through:**
+
+```
+When the import completes, the imports controller calls the finalizer service,
+which updates the status column on the imports table to "finished" via a
+persistence callback. A post-commit hook enqueues the notification job on the
+background queue, which reads the workspace notification settings and delivers
+through the import mailer.
+```
+
+✅ **Good — same facts, tester's language:**
+
+```
+**What happens:**
+- The import's status changes to "Finished" and the page updates with the final created/updated/skipped counts.
+- Everyone subscribed to the workspace gets an email summary — sent in the background, so it can arrive a few seconds late.
+- The import appears in the workspace's history.
+**Edge cases:**
+- An import with no valid rows still finishes, showing 0 created.
+- If notifications are turned off for the workspace, no email is sent — the import still finishes normally.
+```
+
+The bad version is not wrong, it's unusable: nothing in it can be clicked,
+observed, or verified from the UI.
+
+## Contrast — padding vs. answering
+
+**Q: "Can I rename a workspace?"**
+
+❌ **Bad:**
+
+```
+Great question! Let me walk you through workspace renaming. Workspaces in the
+system have a name attribute which can be modified. Here's what I found:
+**What it does:** allows renaming a workspace.
+**Who can do it:** users with permission.
+**Rules / limits:** N/A
+**Edge cases:** N/A
+```
+
+✅ **Good:**
+
+```
+Yes. Workspace Settings → General → change the name → Save.
+Only the workspace owner can do it; admins see the field disabled.
+The name must be unique inside the account, 3–60 characters.
+The workspace URL doesn't change when you rename — it keeps the original slug.
+```
+
+No preamble, no empty sections, and it ends on the detail a tester would
+otherwise discover the hard way.

--- a/skills/qa-thinking/SKILL.md
+++ b/skills/qa-thinking/SKILL.md
@@ -8,6 +8,7 @@ description: Analyze a feature a developer is building from a QA perspective —
 Think about a feature like a senior QA engineer and surface risk scenarios.
 The user can explain the idea, or take it from the current branch or PR.
 For a PR, gather intent with the `qa-pr-requirements-analyzer` skill first.
+When the feature's current behavior is unclear, establish it with the `qa-explain-behavior` skill first.
 
 ## Think
 

--- a/skills/testing-workflow/SKILL.md
+++ b/skills/testing-workflow/SKILL.md
@@ -13,6 +13,7 @@ Orchestrates the test case lifecycle by routing requests to specialized skills a
 | ------------------------------------ | --------------------------------------------------------------------------------- |
 | `scan-automation-project`            | Scan source code to inventory languages, frameworks, and existing tests           |
 | `pull-request-diff-analyzer`         | Analyze a PR/branch diff to detect features/fixes and extract acceptance criteria |
+| `qa-explain-behavior`                | Explain what the product does — features, flows, permissions, edge cases, gaps    |
 | `qa-thinking`                        | Analyze a feature as QA — edge cases, negative flows, abuses, risk scenarios      |
 | `qa-split-testing-levels-pyramid`    | Apply the test pyramid — assign scenarios to testing levels, coverage split       |
 | `qa-write-test-cases`                | Generate new test cases and checklists from requirements                          |
@@ -33,6 +34,7 @@ Orchestrates the test case lifecycle by routing requests to specialized skills a
 - Match the request to a flow below. Delegate to that flow's skill, then suggest its next actions.
 - Flows are examples, not exhaustive. Combine or extend them when a request spans several tasks.
 - When suggesting next steps, take into account the flows, context, user request, and results of previous steps.
+- **Behavior questions** ("what happens when…", "can a user…", "is X supported") ask what the product does rather than for an artifact → route to the `qa-explain-behavior` skill first, then continue with the flow the answer points to.
 - **Strategic intent** ("where do I start", "improve our QA process", "QA maturity review") → route to the `qa-lead-strategy-advisor` skill instead. It owns the high-level roadmap and delegates execution back here.
 
 ## Basic Flows


### PR DESCRIPTION
Answers a QA engineer's questions about product behavior — what features exist, how flows work, who can do what, what the edge cases are, and what is not implemented — by reading the codebase and translating it into tester language, never implementation detail.

Every other skill in the catalog acts on test artifacts (generate, improve, sync, automate). None answered "what does this product actually do?", which is the question that comes before writing a single test case. It slots in ahead of qa-thinking and qa-write-test-cases.

Ported from an internal skill and generalized off Rails: the stack section is now a cheat-sheet where Rails sits alongside Node/Nest, Django/FastAPI and Laravel, rather than being the assumed default.

Wired into the qa-process plugin, the testing-workflow routing registry, and the README tables, with a reciprocal cross-reference from qa-thinking.

Drive-by fix: qa-process was missing from .claude-plugin/marketplace.json despite having a full plugin.json and a README row, so nothing inside it was installable from the marketplace.