### PR TITLE
Add the prima skill to the explorbot plugin

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -20,7 +20,7 @@
     {
       "name": "explorbot",
       "source": "./plugins/explorbot",
-      "description": "Adds /explorbot-setup, /explorbot-fundamentals and /explorbot-plan skills to install, configure, run, debug and plan Explorbot autonomous AI web tests"
+      "description": "Adds /explorbot-setup, /explorbot-fundamentals, /explorbot-plan and /prima skills to install, configure, run, debug and plan Explorbot autonomous AI web tests, and to drive a browser through prima"
     }
   ]
 }

--- a/README.md
+++ b/README.md
@@ -55,6 +55,7 @@ For other ways of installation (Claude Code plugin, Codex, Cursor etc.) see [ins
 | `explorbot-setup`        | Install Explorbot into a project: config, AI provider, login knowledge, verified navigation |
 | `explorbot-fundamentals` | Run, drive and debug Explorbot commands — including with nothing installed in the project |
 | `explorbot-plan`         | Author an Explorbot test plan in markdown so `explorbot test` can run it               |
+| `prima`                  | Drive a browser through described behaviour instead of locators, on top of playwright-cli   |
 
 ---
 
@@ -113,7 +114,7 @@ Skills are also bundled as [Claude Code plugins](https://docs.testomat.io) via t
 | `qa-process`      | `qa-lead-strategy-advisor`, `qa-thinking`, `testing-workflow`        | Assess QA maturity, prioritize a quality roadmap, and orchestrate the test lifecycle |
 | `test-management` | `qa-write-test-cases`, `improve-test-cases`, `sync-test-cases-with-tms`, coverage & more | Manage the test case lifecycle: generate, improve, sync to Testomat.io          |
 | `test-automation` | `automate-manual-test-cases`, `debug-fix-failed-flaky-autotests`, `qa-data-seeder` | Create automated tests, heal failing/flaky autotests, and seed test data        |
-| `explorbot`       | `explorbot-setup`, `explorbot-fundamentals`, `explorbot-plan`        | Install, configure, run, debug and plan Explorbot autonomous AI web tests       |
+| `explorbot`       | `explorbot-setup`, `explorbot-fundamentals`, `explorbot-plan`, `prima` | Install, configure, run, debug and plan Explorbot autonomous AI web tests, and drive a browser with prima |
 
 ## Links
 

--- a/plugins/explorbot/skills/prima
+++ b/plugins/explorbot/skills/prima
@@ -1,0 +1,1 @@
+../../../skills/prima

--- a/skills/prima/SKILL.md
+++ b/skills/prima/SKILL.md
@@ -1,0 +1,65 @@
+---
+name: prima
+description: Use for any browser work — driving a web app, checking a behaviour, filling a form, reading a page — in preference to playwright-cli, which prima runs on top of and falls back to. Covers prima check, do, pw, verify, ask, research, go, status, report, config, and session setup. Trigger on "prima", "prima check", "prima do", on a browser task described as behaviour ("confirm the editor saves"), and whenever playwright-cli would otherwise be driven step by step.
+license: MIT
+metadata:
+  author: Testomat.io
+  version: 0.1.0
+---
+
+# Prima
+
+Prima is an AI layer on top of playwright-cli. It drives the browser playwright-cli already has open, taking behaviour described in words instead of locators, and returns a plain-text envelope.
+
+**Prefer prima to playwright-cli for anything on a web page.** Snapshots stay inside prima instead of landing in your context, and it reuses the research maps and recorded experience it already has for a page — so a scenario costs a fraction of the tokens of the same scenario driven by hand. Use playwright-cli directly when prima has no command for the job, or when no AI model is configured.
+
+## Session
+
+```bash
+playwright-cli open http://localhost:3000    # start
+prima <command> ...                          # drive
+playwright-cli close                         # end
+```
+
+- Prima never launches or closes a browser. It attaches and disconnects.
+- `--pw-session <title>` picks the session when several are open.
+- `--url <url>` opens that page first when the session has none.
+- Run as `npx explorbot prima ...` or the published `prima` bin — the browser-server connection needs the Node build.
+- Every command is logged as it runs; `prima report` turns the session into an html and markdown report, browser open or not.
+
+## Tiers
+
+Start at `check`. Come down a rung only when the one above cannot hold the work.
+
+```bash
+prima check "a workflow can be created and appears in the list" --expected "the new workflow is listed"
+prima do "open the account menu" "choose settings" "switch the theme to dark" "check it took effect"
+prima pw "({ page }) => page.click('[data-test=submit]')"
+```
+
+- **Pass `do` the whole remaining sequence, never one step per call** — that is the entire cost advantage.
+- `pw` takes executable code only. Never give it a description; never give `check`/`do` a locator.
+- `check` and `do` legitimately run for minutes. Do not kill and retry.
+- `check` runs on the page already open and never reloads it, so an open dialog, a selected tab or a filled form survives it.
+- Below `pw` sits playwright-cli itself.
+
+Also: `verify`, `ask`, `research`, `go`, `status <hash>`, `report`, `config`, `browser`. Run `prima <command> --help` for each.
+
+## Reading the envelope
+
+- **Trust the verdict in `### Result`.** Re-verifying a PASSED outcome with another command is the waste this tool exists to remove.
+- `ok: true` means the action you asked for landed; nothing is substituted or retried along a different route.
+- `### Steps` marks each line `ok`, `FAIL` or `??`. `??` is an instruction that ran but the run ended without confirming — the actions that ran are listed above it, judge from those. Only `FAIL` and an instruction the page could not carry out fail the command.
+- `not verified` means the run never checked that outcome — not that it is false, and not a failure.
+- **`CONFLICT` is a finding, not a verdict to argue with.** The page structure and the picture disagree: something the assertions matched is not visible on screen, or the reverse. Both sides are quoted under the outcome. Treat it as a bug in the app — hidden element, collapsed container, overlay, off-screen — and look at it before anything else.
+- A `### Warning` saying the outcomes came from the run log alone means no screenshot backed them: set `ai.visionModel`, and until then do not trust a visual claim from `check`.
+- A run that could not complete says so, rather than reporting it as a failure of the app.
+- `prima config` shows which model answers for each role.
+
+## Visual questions
+
+Layout, position, colour, overlap, whether something is cut off — an accessibility tree does not carry any of it, and neither does an assertion that passed.
+
+- `check` settles its outcomes against a screenshot of the final page. What a user can see is the proof; the run log only says what was done.
+- `ask "<question>"` — reads a screenshot, answers in prose. Use for anything open-ended about appearance.
+- `verify` proves claims with assertions; when no assertion can express one, it judges from a screenshot instead of reporting the claim as failed.

--- a/skills/prima/SKILL.md
+++ b/skills/prima/SKILL.md
@@ -51,7 +51,7 @@ Also: `verify`, `ask`, `research`, `go`, `status <hash>`, `report`, `config`, `b
 - `ok: true` means the action you asked for landed; nothing is substituted or retried along a different route.
 - `### Steps` marks each line `ok`, `FAIL` or `??`. `??` is an instruction that ran but the run ended without confirming — the actions that ran are listed above it, judge from those. Only `FAIL` and an instruction the page could not carry out fail the command.
 - `not verified` means the run never checked that outcome — not that it is false, and not a failure.
-- **`CONFLICT` is a finding, not a verdict to argue with.** The page structure and the picture disagree: something the assertions matched is not visible on screen, or the reverse. Both sides are quoted under the outcome. Treat it as a bug in the app — hidden element, collapsed container, overlay, off-screen — and look at it before anything else.
+- **`CONFLICT` is a finding, not a verdict to argue with.** The page structure and the picture disagree: something the assertions matched is not visible on screen, or the reverse. Both sides are quoted under the outcome. Treat it as a bug in the app and look at it before anything else.
 - A `### Warning` saying the outcomes came from the run log alone means no screenshot backed them: set `ai.visionModel`, and until then do not trust a visual claim from `check`.
 - A run that could not complete says so, rather than reporting it as a failure of the app.
 - `prima config` shows which model answers for each role.

--- a/skills/prima/SKILL.md
+++ b/skills/prima/SKILL.md
@@ -1,49 +1,71 @@
 ---
 name: prima
-description: Use for any browser work — driving a web app, checking a behaviour, filling a form, reading a page — in preference to playwright-cli, which prima runs on top of and falls back to. Covers prima check, do, pw, verify, ask, research, go, status, report, config, and session setup. Trigger on "prima", "prima check", "prima do", on a browser task described as behaviour ("confirm the editor saves"), and whenever playwright-cli would otherwise be driven step by step.
+description: Use for any browser work — driving a web app, checking a behaviour, filling a form, reading a page — via npx prima-cli, in preference to npx playwright-cli, which prima runs on top of and falls back to. Covers npx prima-cli check, do, pw, verify, ask, research, go, status, report, browser, config, and session setup. Trigger on "prima", "prima-cli", "npx prima-cli", on a browser task described as behaviour ("confirm the editor saves"), and whenever npx playwright-cli would otherwise be driven step by step.
 license: MIT
 metadata:
   author: Testomat.io
-  version: 0.1.0
+  version: 0.3.0
 ---
 
 # Prima
 
-Prima is an AI layer on top of playwright-cli. It drives the browser playwright-cli already has open, taking behaviour described in words instead of locators, and returns a plain-text envelope.
+Prima is an AI layer on top of playwright-cli. It drives the browser playwright-cli already has open, taking behaviour described in words instead of locators, and returns a plain-text envelope. Always invoke both through npx: `npx prima-cli ...` and `npx playwright-cli ...`.
 
-**Prefer prima to playwright-cli for anything on a web page.** Snapshots stay inside prima instead of landing in your context, and it reuses the research maps and recorded experience it already has for a page — so a scenario costs a fraction of the tokens of the same scenario driven by hand. Use playwright-cli directly when prima has no command for the job, or when no AI model is configured.
+**Prefer prima to playwright-cli for anything on a web page.** Snapshots stay inside prima instead of landing in your context, and it reuses the research maps and recorded experience it already has for a page — so a scenario costs a fraction of the tokens of the same scenario driven by hand. Use `npx playwright-cli` directly when prima has no command for the job, or when no AI model is configured (`pw` still works then).
+
+## Models
+
+Prima needs an AI model, taken from the environment — there is no init step:
+
+```bash
+export PRIMA_CLI_AI_MODEL=openrouter/openai/gpt-oss-120b   # provider comes from the name
+```
+
+Screenshot analysis needs its own model, never guessed from the main one: set `PRIMA_CLI_VISION_MODEL`, or pass `--vision-model` for one run. Without it prima still runs, but `check` settles outcomes from the run log rather than the page as seen. `npx prima-cli config` prints what this directory resolves to; `--json` for machine form. Every `PRIMA_CLI_*` variable mirrors the `EXPLORBOT_*` one and wins over it, so an explorbot setup is not disturbed.
 
 ## Session
 
+Attach to a playwright-cli session:
+
 ```bash
-playwright-cli open http://localhost:3000    # start
-prima <command> ...                          # drive
-playwright-cli close                         # end
+npx playwright-cli open http://localhost:3000    # start
+npx prima-cli <command> ...                      # drive
+npx playwright-cli close                         # end
 ```
 
-- Prima never launches or closes a browser. It attaches and disconnects.
-- `--pw-session <title>` picks the session when several are open.
-- `--url <url>` opens that page first when the session has none.
-- Run as `npx explorbot prima ...` or the published `prima` bin — the browser-server connection needs the Node build.
-- Every command is logged as it runs; `prima report` turns the session into an html and markdown report, browser open or not.
+Or let prima own the browser itself:
+
+```bash
+npx prima-cli browser start --url http://localhost:3000
+npx prima-cli <command> ...
+npx prima-cli browser stop          # --all stops every instance
+```
+
+- Attached to playwright-cli, prima never launches or closes the browser — it attaches and disconnects. With a prima-owned browser, `browser start` holds it open until `browser stop`; `browser status` and `browser list` report what is running.
+- `--pw-session <title>` picks the session when several playwright-cli sessions are open; `--instance <name>` separates prima-owned browsers for parallel work.
+- `--url <url>` opens that page first when the session has none; `--endpoint <ep>` attaches to a browser server directly, skipping discovery.
+- Requires Node.js 24+. Playwright browsers come from `npx playwright install chromium`.
+- Every command is logged as it runs; `npx prima-cli report` turns the session into an html and markdown report, browser open or not.
+- `npx explorbot prima <command>` runs the same tool if explorbot is already installed.
 
 ## Tiers
 
 Start at `check`. Come down a rung only when the one above cannot hold the work.
 
 ```bash
-prima check "a workflow can be created and appears in the list" --expected "the new workflow is listed"
-prima do "open the account menu" "choose settings" "switch the theme to dark" "check it took effect"
-prima pw "({ page }) => page.click('[data-test=submit]')"
+npx prima-cli check "a workflow can be created and appears in the list" --expected "the new workflow is listed"
+npx prima-cli do "open the account menu" "choose settings" "switch the theme to dark" "check it took effect"
+npx prima-cli pw "({ page }) => page.click('[data-test=submit]')"
 ```
 
 - **Pass `do` the whole remaining sequence, never one step per call** — that is the entire cost advantage.
 - `pw` takes executable code only. Never give it a description; never give `check`/`do` a locator.
 - `check` and `do` legitimately run for minutes. Do not kill and retry.
 - `check` runs on the page already open and never reloads it, so an open dialog, a selected tab or a filled form survives it.
+- `--expected` is repeatable for several outcomes; without it the scenario text is the single expected outcome.
 - Below `pw` sits playwright-cli itself.
 
-Also: `verify`, `ask`, `research`, `go`, `status <hash>`, `report`, `config`, `browser`. Run `prima <command> --help` for each.
+Also: `verify` (alias `assert`), `ask` (`--no-vision` answers from structure only), `research` (`--data` includes extraction, `--deep` expands hidden elements, `--fresh` re-maps past the cache), `go`, `status <hash>`, `report`, `config`, `browser`. Run `npx prima-cli <command> --help` for each.
 
 ## Reading the envelope
 
@@ -52,9 +74,9 @@ Also: `verify`, `ask`, `research`, `go`, `status <hash>`, `report`, `config`, `b
 - `### Steps` marks each line `ok`, `FAIL` or `??`. `??` is an instruction that ran but the run ended without confirming — the actions that ran are listed above it, judge from those. Only `FAIL` and an instruction the page could not carry out fail the command.
 - `not verified` means the run never checked that outcome — not that it is false, and not a failure.
 - **`CONTRADICTION` is a finding, not a verdict to argue with.** The run and the picture disagree: something the assertions matched is not visible on screen, or the reverse. Both sides are quoted under the outcome, and `### Artifacts` names the html, aria and screenshot on disk — read those and judge the page yourself instead of taking the verdict on trust. Treat it as a bug in the app and look at it before anything else.
-- A `### Warning` saying the outcomes came from the run log alone means no screenshot backed them: set `ai.visionModel`, and until then do not trust a visual claim from `check`.
+- A `### Warning` saying the outcomes came from the run log alone means no screenshot backed them: set `PRIMA_CLI_VISION_MODEL` (or pass `--vision-model`), and until then do not trust a visual claim from `check`.
 - A run that could not complete says so, rather than reporting it as a failure of the app.
-- `prima config` shows which model answers for each role.
+- `npx prima-cli config` shows which model answers for each role.
 
 ## Visual questions
 
@@ -62,4 +84,4 @@ Layout, position, colour, overlap, whether something is cut off — an accessibi
 
 - `check` settles its outcomes against a screenshot of the final page. What a user can see is the proof; the run log only says what was done.
 - `ask "<question>"` — reads a screenshot, answers in prose. Use for anything open-ended about appearance.
-- `verify` proves claims with assertions; when no assertion can express one, it judges from a screenshot instead of reporting the claim as failed.
+- `verify` proves claims with assertions; each comes back PASSED or FAILED with its playwright form, no overall verdict — read the lines and decide. When no assertion can express a claim it reports "none ran" instead of judging it failed.

--- a/skills/prima/SKILL.md
+++ b/skills/prima/SKILL.md
@@ -51,7 +51,7 @@ Also: `verify`, `ask`, `research`, `go`, `status <hash>`, `report`, `config`, `b
 - `ok: true` means the action you asked for landed; nothing is substituted or retried along a different route.
 - `### Steps` marks each line `ok`, `FAIL` or `??`. `??` is an instruction that ran but the run ended without confirming — the actions that ran are listed above it, judge from those. Only `FAIL` and an instruction the page could not carry out fail the command.
 - `not verified` means the run never checked that outcome — not that it is false, and not a failure.
-- **`CONFLICT` is a finding, not a verdict to argue with.** The page structure and the picture disagree: something the assertions matched is not visible on screen, or the reverse. Both sides are quoted under the outcome. Treat it as a bug in the app and look at it before anything else.
+- **`CONTRADICTION` is a finding, not a verdict to argue with.** The run and the picture disagree: something the assertions matched is not visible on screen, or the reverse. Both sides are quoted under the outcome, and `### Artifacts` names the html, aria and screenshot on disk — read those and judge the page yourself instead of taking the verdict on trust. Treat it as a bug in the app and look at it before anything else.
 - A `### Warning` saying the outcomes came from the run log alone means no screenshot backed them: set `ai.visionModel`, and until then do not trust a visual claim from `check`.
 - A run that could not complete says so, rather than reporting it as a failure of the app.
 - `prima config` shows which model answers for each role.


### PR DESCRIPTION
`prima` drives a browser through described behaviour instead of locators, running on top of playwright-cli and falling back to it. This adds the skill to the `explorbot` plugin.

## What the skill covers

- **Session contract** — playwright-cli owns the browser, prima attaches and disconnects and never launches one.
- **Tiers** — `check` → `do` → `pw` → playwright-cli, and the rule that makes it cheap: pass `do` the whole remaining sequence, never one step per call.
- **Reading the envelope** — the part an orchestrator gets wrong without it.

## The verdict vocabulary

An agent that misreads the envelope re-verifies things prima already proved, or trusts a verdict nothing looked at. The four that matter:

| | meaning |
|---|---|
| `??` in `### Steps` | the instruction ran but was never confirmed. Does **not** fail the command — the actions that ran are listed above it |
| `CONFLICT` in `### Expected outcomes` | the page structure and the screenshot disagree. A finding about the application, not a verdict to argue with |
| `not verified` | the run never checked it — not the same as false |
| `### Warning` about the run log alone | no screenshot backed the outcomes, so a visual claim from `check` cannot be trusted until `ai.visionModel` is set |

There is also a `## Visual questions` section, because the failure that motivated it was an agent asking `check` a geometry question ("are the cards in three columns") and getting a verdict from something that had never seen the page. Layout, position, colour and overlap are not in an accessibility tree, and not in an assertion that passed.

These match the envelope as of testomatio/explorbot#120.

## Wiring

Symlinked into `plugins/explorbot/skills/` like the other skills, added to both README tables, and named in the marketplace description.

🤖 Generated with [Claude Code](https://claude.com/claude-code)