### PR TITLE
feat: add qa-explain-behavior skill

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -18,6 +18,11 @@
       "description": "Adds a /test-automation skill for test automation (create, heal, sync results, etc)"
     },
     {
+      "name": "qa-process",
+      "source": "./plugins/qa-process",
+      "description": "Strategic QA process advisory — assess QA maturity, prioritize a roadmap, explain product behavior, think through quality risks, and orchestrate the test lifecycle"
+    },
+    {
       "name": "explorbot",
       "source": "./plugins/explorbot",
       "description": "Adds /explorbot-setup, /explorbot-fundamentals and /explorbot-plan skills to install, configure, run, debug and plan Explorbot autonomous AI web tests"

--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@ For other ways of installation (Claude Code plugin, Codex, Cursor etc.) see [ins
 
 | Skill                  | Description                                                                                          |
 | ---------------------- | ---------------------------------------------------------------------------------------------------- |
+| `qa-explain-behavior`  | Answer QA questions about product behavior — features, flows, rules, edge cases, and what is not implemented |
 | `qa-write-test-cases`       | Generate test cases and checklists from requirements, tickets, or feature descriptions               |
 | `qa-thinking`          | Analyze a feature from a QA perspective — edge cases, negative flows, abuses, unobvious scenarios |
 | `qa-split-testing-levels-pyramid` | Apply the test pyramid to a feature — assign scenarios to testing levels, coverage split per level |
@@ -110,7 +111,7 @@ Skills are also bundled as [Claude Code plugins](https://docs.testomat.io) via t
 
 | Plugin            | Bundled skills                                                       | Use it to                                                                       |
 | ----------------- | ------------------------------------------------------------------- | ------------------------------------------------------------------------------ |
-| `qa-process`      | `qa-lead-strategy-advisor`, `qa-thinking`, `testing-workflow`        | Assess QA maturity, prioritize a quality roadmap, and orchestrate the test lifecycle |
+| `qa-process`      | `qa-lead-strategy-advisor`, `qa-explain-behavior`, `qa-thinking`, `testing-workflow` | Assess QA maturity, prioritize a quality roadmap, explain product behavior, and orchestrate the test lifecycle |
 | `test-management` | `qa-write-test-cases`, `improve-test-cases`, `sync-test-cases-with-tms`, coverage & more | Manage the test case lifecycle: generate, improve, sync to Testomat.io          |
 | `test-automation` | `automate-manual-test-cases`, `debug-fix-failed-flaky-autotests`, `qa-data-seeder` | Create automated tests, heal failing/flaky autotests, and seed test data        |
 | `explorbot`       | `explorbot-setup`, `explorbot-fundamentals`, `explorbot-plan`        | Install, configure, run, debug and plan Explorbot autonomous AI web tests       |

--- a/plugins/qa-process/skills/qa-explain-behavior
+++ b/plugins/qa-process/skills/qa-explain-behavior
@@ -1,0 +1,1 @@
+../../../skills/qa-explain-behavior

--- a/skills/qa-explain-behavior/SKILL.md
+++ b/skills/qa-explain-behavior/SKILL.md
@@ -1,0 +1,111 @@
+---
+name: qa-explain-behavior
+description: Answers QA questions about product behavior — what features exist, how user flows work, what business rules apply, what edge cases the system handles, and what is or is not implemented. Use whenever the user asks a question about WHAT the system does (features, flows, rules, conditions, who-can-do-what, when-does-X-happen, is-Y-supported). Trigger even when the user does not say "QA" — phrases like "what happens when…", "can a user…", "is it possible to…", "does the system…", "is X implemented", "what should I test for…", "what are the edge cases of…", or "walk me through the flow for…" all qualify. Do NOT trigger for questions that are clearly about implementation (architecture, database schema, code structure, performance, types, dependencies).
+license: MIT
+metadata:
+  author: Testomat.io
+  version: 1.0.0
+---
+
+# QA Explain Behavior
+
+Answer a QA engineer who is testing the product. They care about **product behavior**, not implementation. Read the codebase like a manual and translate it into plain-language descriptions of what the system does.
+
+| What | File |
+|------|------|
+| Output shape per question type — feature, flow, yes/no, permissions, edge cases | [references/answer-shapes.md](references/answer-shapes.md) |
+| Worked answers, plus bad-vs-good contrasts | [references/examples.md](references/examples.md) |
+
+## The mindset shift
+
+The QA engineer is not going to read the code. They are going to click buttons, fill forms, and try to break things. The answer should help them know what to click, what to expect, and where the product might fail. Describe the product like someone who has used it end-to-end.
+
+A QA engineer's mental model is built from:
+
+- **Actors** — who is doing this: guest, member, admin, owner, integration.
+- **Actions** — what they do: click, submit, upload, invite.
+- **Outcomes** — what they see or what changes: page, message, email, status.
+- **Rules** — when it's allowed, when it's blocked, what limits apply.
+- **Edge cases** — empty state, very large input, duplicate, expired, offline.
+
+Frame every answer in those terms.
+
+## What to investigate
+
+Look at the parts of the codebase that **describe behavior**, not the parts that describe data:
+
+- **Service and controller layers** — what user actions exist, and the multi-step flows behind them.
+- **Business logic** — the rules that decide what is allowed, what changes, and what happens next.
+- **Authorization and permissions system** — who can do what, and whether the block is in the UI, on the server, or both.
+- **Feature flags** — what is switched on, off, or limited to certain accounts.
+- **Configuration** — limits, defaults, and behavior that differs per environment or plan.
+- **Models** — only *validations*, *state machines*, *callbacks*, and *scopes with business meaning*. Not columns, associations, or types.
+- **Views, serializers, mailers** — what the user sees and receives.
+- **Background jobs** — what happens after the user-visible action: notifications, syncs, cleanups.
+- **Tests** — they describe expected behavior in plain English; very useful.
+
+## What to ignore
+
+Unless the user explicitly asks, never mention:
+
+- Database tables, columns, indexes, schema.
+- Class names, file paths, line numbers, module structure.
+- Framework terminology and internals — ORM concepts, callbacks, middleware, queues, dependencies.
+- Variable names, method names, parameters, types.
+- SQL, code snippets, regex.
+- Performance, scaling, architecture decisions.
+- Migration history, refactors.
+
+If the user wants this, they will ask. The default is product-level only.
+
+## How to answer
+
+**Be compact.** A QA engineer scans, they don't read paragraphs. Short bullets, short sentences, plain words.
+
+**Lead with the answer.** No preamble, no restating the question, no "Let me explain…".
+
+**Use product vocabulary, not code vocabulary:**
+
+- "the user", "the admin", "the workspace owner" — not `current_user`.
+- "the settings page" — not a controller action name.
+- "an email is sent" — not a mailer class.
+- "it's blocked" — not "validation fails".
+- "in the background" — not the name of the queue.
+
+**Structure by what a tester needs.** When describing a feature, default to this shape:
+
+```
+**What it does:** one line
+**Who can do it:** roles / permissions
+**How to trigger it:** user action(s)
+**What happens:** outcomes (UI, emails, notifications, status changes)
+**Rules / limits:** validations, conditions
+**Edge cases:** empty, duplicate, large, expired, blocked, etc.
+**Not implemented:** anything the QA might expect that does NOT exist
+```
+
+For flow questions, describe the flow as numbered steps from the user's point of view. For "is X supported?" questions, answer **yes** or **no** first, then a one-line reason, then any nuance. Permission questions, edge-case sweeps, failure behavior, comparisons, and how to phrase uncertainty each have their own shape in [references/answer-shapes.md](references/answer-shapes.md).
+
+**Surface what is missing.** The most valuable thing a QA engineer can hear is "this is not implemented", "there is no UI for this — only the API supports it", or "this only works for paying accounts". Always look for gaps and call them out: a flag, a TODO, a commented-out path, an action reachable only via API.
+
+**Be honest about uncertainty.** If the codebase is ambiguous, say "I see X but I'm not sure whether Y" rather than guessing. A QA testing on a wrong assumption is worse than a QA who knows to verify.
+
+## Do not write code
+
+Never produce code blocks, schema, configuration snippets, or pseudocode unless the user explicitly asks ("show me the code", "give me the SQL"). The default response is prose and bullets only. When tempted to paste code "to be helpful", describe the behavior instead.
+
+When the product **is** a CLI or an API, the commands, flags, and endpoints a user types are product surface, not implementation — name them exactly, the same way you would name a button.
+
+[references/examples.md](references/examples.md) has worked answers — a full feature description, a flow walkthrough, an edge-case sweep — and two bad-vs-good contrasts showing what code leaking into an answer looks like.
+
+## Next actions
+
+Offer after the answer:
+
+- Turn the behavior into risk scenarios → `qa-thinking` skill.
+- Turn it into test cases or a checklist → `qa-write-test-cases` skill.
+- Map which tests already cover it → `qa-test-code-coverage` skill.
+
+## Final reminder
+
+Compact. Plain language. Behavior, not code. Highlight gaps. No code unless asked.

--- a/skills/qa-explain-behavior/references/answer-shapes.md
+++ b/skills/qa-explain-behavior/references/answer-shapes.md
@@ -1,0 +1,116 @@
+# Answer shapes
+
+Pick the shape that matches the question. Skip any section that doesn't apply —
+never pad with "N/A" or "None". Bullets over paragraphs, short lines, plain
+words.
+
+## Feature description — "what does X do", "explain X"
+
+The default shape. Most questions land here.
+
+```
+**What it does:** one line
+**Who can do it:** roles / permissions
+**How to trigger it:** the clicks, in order
+**What happens:** outcomes — screen, message, email, status change, background work
+**Rules / limits:** validations, conditions, plan gating
+**Edge cases:** empty, duplicate, too large, expired, blocked, concurrent
+**Not implemented:** anything a tester would reasonably expect that doesn't exist
+```
+
+## Flow walkthrough — "walk me through…", "how does someone…"
+
+Numbered steps from the user's point of view, one screen per step. Say where
+the flow can branch or die.
+
+```
+1. User clicks **X** on the … page.
+2. …
+3. …
+
+**Branches:**
+- If <condition>, they land on … instead.
+- If <condition>, it stops with "<the actual message>".
+
+**After it finishes:** <emails, notifications, anything delayed>
+```
+
+## Yes / no — "is X supported", "can I…", "is there a way to…"
+
+Answer in the first word. Then one line of why. Then nuance, if any.
+
+```
+Yes — partially.
+- <what works, and where>
+- <what doesn't>
+- <what exists in the API but has no UI>
+```
+
+If it's a flat no, one or two lines is the whole answer. Don't inflate it.
+
+## Permissions — "can a *role* do X", "who can…"
+
+Say whether the block is in the UI, on the server, or both — a tester needs to
+know if they can get past it by calling the API directly.
+
+```
+No. Guests can view … but cannot …
+The button is hidden for guests, and the action is blocked server-side too.
+```
+
+For several roles at once, use a small table:
+
+```
+| Role | Create | Edit | Delete |
+|---|---|---|---|
+| Owner | ✅ | ✅ | ✅ |
+| Member | ✅ | ✅ | ❌ |
+| Guest | ❌ | ❌ | ❌ |
+```
+
+## Edge cases — "what could go wrong", "what should I test"
+
+Group by the kind of input or state, so the list is walkable as a test session.
+Each line is a condition plus what actually happens.
+
+```
+**Empty / missing:** …
+**Duplicate:** …
+**Too large / too many:** …
+**Wrong format:** …
+**Expired / stale:** …
+**Permissions:** …
+**Concurrent:** two people doing this at once …
+**External failure:** the integration is down / the upload fails …
+```
+
+## Failure behaviour — "what happens if it fails"
+
+Testers need the observable result, not the exception.
+
+```
+**What the user sees:** the actual message or screen
+**What state it's left in:** saved / not saved / half-saved
+**Whether it retries:** automatically, manually, or not at all
+```
+
+## Comparison — "what's the difference between X and Y"
+
+Two columns, same rows. Only rows where they actually differ.
+
+## Phrasing uncertainty
+
+Never guess silently. Use the shape "I can see X, but I couldn't confirm Y":
+
+- "The API accepts this, but I couldn't find a UI that reaches it."
+- "There's a limit of 100 here, but I'm not sure whether it's enforced on
+  import as well — worth verifying."
+- "This looks gated by a feature flag. Whether it's on for your account, I
+  can't tell from the code."
+
+## Length
+
+Match the question. A yes/no question gets two lines. A "walk me through the
+whole import flow" gets a full shape. If your answer runs past about a screen,
+either the question was broad or you're explaining implementation — check
+which.

--- a/skills/qa-explain-behavior/references/examples.md
+++ b/skills/qa-explain-behavior/references/examples.md
@@ -1,0 +1,157 @@
+# Worked examples
+
+> The product below is **invented** — a generic workspace app with members,
+> documents and file imports. These examples show the shape and register of a
+> good answer, not real behaviour. Always answer from what you actually find in
+> the codebase in front of you.
+
+## Example 1 — feature description
+
+**Q: "What happens when a user is invited to a workspace?"**
+
+```
+**What it does:** sends an invitation so someone can join a workspace with a chosen role.
+**Who can do it:** workspace owner and admins.
+**How to trigger:** Workspace Settings → Members → "Invite" → enter email + pick role.
+**What happens:**
+- Invitation email is sent to that address.
+- Pending invite shows in the members list.
+- If the email matches an existing user, they accept by clicking the link and the workspace appears in their sidebar.
+- If not, they're prompted to register first; after register they land on the workspace.
+**Rules:**
+- Email must be valid.
+- Same email can't have two pending invites for the same workspace.
+- Role must be one of: owner, admin, member, guest.
+**Edge cases:**
+- Invite link expires after 7 days.
+- If the invited user is already a member, the invite is rejected with a message.
+- Re-sending an invite resets the expiry.
+**Not implemented:** bulk invite via CSV is not available in the UI.
+```
+
+Why it works: every line is something a tester can act on. The last line is the
+most valuable one in the answer.
+
+## Example 2 — permission question
+
+**Q: "Can a guest delete a document?"**
+
+```
+No. Guests can view documents but cannot edit, create, or delete them. The
+delete button is hidden for guests, and the action is also blocked server-side.
+```
+
+Two lines, and it answers the follow-up question a tester was about to ask —
+whether the block survives a direct API call.
+
+## Example 3 — support question with nuance
+
+**Q: "Is there a way to export a document?"**
+
+```
+Yes — partially.
+- CSV export is available from the document page (top-right menu).
+- PDF export is **not** implemented.
+- The raw JSON can be retrieved via API, but there's no UI button for it.
+```
+
+"Yes — partially" in the first line, then exactly where the line falls.
+
+## Example 4 — flow walkthrough
+
+**Q: "Walk me through importing records from a file."**
+
+```
+1. Workspace → Data → "Import" → pick a file (CSV or XLSX).
+2. A preview shows the first rows with a column-mapping step — you map each
+   column to a field (name, owner, category, tags).
+3. Confirm. The import runs in the background; the page shows a progress state.
+4. When it finishes you get an in-app notification with a summary: created,
+   updated, skipped.
+
+**Branches:**
+- If a row has no name, it's skipped and counted in "skipped".
+- If a record with the same name already exists in that category, it's updated
+  rather than duplicated.
+- If the whole file can't be parsed, nothing is imported and you get an error
+  on the same screen.
+
+**Rules / limits:**
+- File must be under 10 MB.
+- Only CSV and XLSX; other extensions are rejected before upload.
+
+**Edge cases:**
+- An empty file imports nothing and reports "0 created".
+- Closing the tab doesn't cancel the import — it keeps running.
+
+**Not implemented:** there's no way to undo or roll back an import.
+```
+
+## Example 5 — edge-case sweep
+
+**Q: "What should I test around document deletion?"**
+
+```
+**Permissions:** owner and admin can delete; member and guest cannot (hidden and blocked server-side).
+**Empty:** deleting a document with no content works and removes it immediately.
+**In use:** a document open in someone else's tab can be deleted — their next save fails with a generic error, which is worth checking.
+**Linked data:** attached files are removed in the background, so they can outlive the document by a few seconds.
+**Concurrent:** two admins deleting the same document at once — the second gets a "not found" error rather than a friendly message.
+**Undo:** there is none, and there's no confirmation step on the API — only in the UI.
+```
+
+## Contrast — the same question answered badly
+
+**Q: "What happens when an import finishes?"**
+
+❌ **Bad — implementation leaking through:**
+
+```
+When the import completes, the imports controller calls the finalizer service,
+which updates the status column on the imports table to "finished" via a
+persistence callback. A post-commit hook enqueues the notification job on the
+background queue, which reads the workspace notification settings and delivers
+through the import mailer.
+```
+
+✅ **Good — same facts, tester's language:**
+
+```
+**What happens:**
+- The import's status changes to "Finished" and the page updates with the final created/updated/skipped counts.
+- Everyone subscribed to the workspace gets an email summary — sent in the background, so it can arrive a few seconds late.
+- The import appears in the workspace's history.
+**Edge cases:**
+- An import with no valid rows still finishes, showing 0 created.
+- If notifications are turned off for the workspace, no email is sent — the import still finishes normally.
+```
+
+The bad version is not wrong, it's unusable: nothing in it can be clicked,
+observed, or verified from the UI.
+
+## Contrast — padding vs. answering
+
+**Q: "Can I rename a workspace?"**
+
+❌ **Bad:**
+
+```
+Great question! Let me walk you through workspace renaming. Workspaces in the
+system have a name attribute which can be modified. Here's what I found:
+**What it does:** allows renaming a workspace.
+**Who can do it:** users with permission.
+**Rules / limits:** N/A
+**Edge cases:** N/A
+```
+
+✅ **Good:**
+
+```
+Yes. Workspace Settings → General → change the name → Save.
+Only the workspace owner can do it; admins see the field disabled.
+The name must be unique inside the account, 3–60 characters.
+The workspace URL doesn't change when you rename — it keeps the original slug.
+```
+
+No preamble, no empty sections, and it ends on the detail a tester would
+otherwise discover the hard way.

--- a/skills/qa-thinking/SKILL.md
+++ b/skills/qa-thinking/SKILL.md
@@ -8,6 +8,7 @@ description: Analyze a feature a developer is building from a QA perspective —
 Think about a feature like a senior QA engineer and surface risk scenarios.
 The user can explain the idea, or take it from the current branch or PR.
 For a PR, gather intent with the `qa-pr-requirements-analyzer` skill first.
+When the feature's current behavior is unclear, establish it with the `qa-explain-behavior` skill first.
 
 ## Think
 

--- a/skills/testing-workflow/SKILL.md
+++ b/skills/testing-workflow/SKILL.md
@@ -13,6 +13,7 @@ Orchestrates the test case lifecycle by routing requests to specialized skills a
 | ------------------------------------ | --------------------------------------------------------------------------------- |
 | `scan-automation-project`            | Scan source code to inventory languages, frameworks, and existing tests           |
 | `pull-request-diff-analyzer`         | Analyze a PR/branch diff to detect features/fixes and extract acceptance criteria |
+| `qa-explain-behavior`                | Explain what the product does — features, flows, permissions, edge cases, gaps    |
 | `qa-thinking`                        | Analyze a feature as QA — edge cases, negative flows, abuses, risk scenarios      |
 | `qa-split-testing-levels-pyramid`    | Apply the test pyramid — assign scenarios to testing levels, coverage split       |
 | `qa-write-test-cases`                | Generate new test cases and checklists from requirements                          |
@@ -33,6 +34,7 @@ Orchestrates the test case lifecycle by routing requests to specialized skills a
 - Match the request to a flow below. Delegate to that flow's skill, then suggest its next actions.
 - Flows are examples, not exhaustive. Combine or extend them when a request spans several tasks.
 - When suggesting next steps, take into account the flows, context, user request, and results of previous steps.
+- **Behavior questions** ("what happens when…", "can a user…", "is X supported") ask what the product does rather than for an artifact → route to the `qa-explain-behavior` skill first, then continue with the flow the answer points to.
 - **Strategic intent** ("where do I start", "improve our QA process", "QA maturity review") → route to the `qa-lead-strategy-advisor` skill instead. It owns the high-level roadmap and delegates execution back here.
 
 ## Basic Flows


### PR DESCRIPTION
## What

Adds `qa-explain-behavior` — a skill that answers a QA engineer's questions about **product behavior**: what features exist, how user flows work, who can do what, what edge cases the system handles, and what is *not* implemented. It reads the codebase and translates it into tester language, never implementation detail.

## Why

Every existing skill in the catalog acts on test artifacts — generate, improve, sync, automate. None answers "what does this product actually do?", which is the question a QA engineer has *before* they can write a single test case. It slots into the lifecycle ahead of `qa-thinking` and `qa-write-test-cases`.

## What's in it

- `skills/qa-explain-behavior/SKILL.md` — orchestration: the mindset shift, what to investigate, what to ignore, how to answer, next actions.
- `references/answer-shapes.md` — output shape per question type: feature, flow, yes/no, permissions, edge cases, failure behavior.
- `references/examples.md` — worked answers plus two bad-vs-good contrasts showing what code leaking into an answer looks like.

The skill is stack-neutral. It names the *roles* to look for — service and controller layers, business logic, the authorization and permissions system, feature flags, configuration, background work — rather than the filenames of any one framework.

The worked examples run on an invented workspace app (members, documents, file imports), so nothing in them describes our own product or reads as verified behaviour.

## Wiring

- Symlinked into the `qa-process` plugin.
- Registered in the `testing-workflow` routing table, with a `## Routing` bullet for behavior questions.
- Added to the README Test Management table and the `qa-process` plugin row.
- Reciprocal cross-reference from `qa-thinking`.

## Drive-by fix

`qa-process` was missing from `.claude-plugin/marketplace.json` despite having a full `plugin.json` and a README row — so nothing symlinked into it was installable from the marketplace. Added the entry. This is pre-existing and unrelated to the new skill, but it blocked delivery.

## Relation to #168

#168 was merged and then reverted in #171. This re-lands the same skill on a fresh branch, this time **skill-only** — the three QA documentation files that rode along in #168 are not included here.

## Testing

No CI or schema validation exists in this repo, so verification was manual:

- Symlink resolves and reads through; recorded as git mode `120000`.
- Frontmatter `name` matches the directory; both reference links resolve.
- No product-specific vocabulary left in the skill outside the `author` field and the `qa-write-test-cases` cross-reference.
- `marketplace.json` parses and lists four plugins.
- Smoke-tested against an unrelated codebase with a real behavior question. The answer led with the outcome, used product vocabulary, included no file paths or class names, and flagged its own uncertainty.

That smoke test surfaced one gap, now fixed: the "do not write code" rule would have forbidden naming CLI commands and API endpoints, which for a CLI or API product *are* the user-facing surface. Added a one-line carve-out.
